### PR TITLE
update: added termination queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Tests for updating the state.
 - Function to update the state and publish blob on ethereum in state update job.
 - Fixtures for testing.
+- Implement DL queue for handling failed jobs.
 
 ## Changed
 

--- a/crates/orchestrator/src/jobs/mod.rs
+++ b/crates/orchestrator/src/jobs/mod.rs
@@ -181,8 +181,13 @@ pub async fn handle_job_failure(id: Uuid) -> Result<()> {
     let mut job = get_job(id).await?.clone();
     let mut metadata = job.metadata.clone();
 
-    if job.status.clone() == JobStatus::Completed {
+    if job.status == JobStatus::Completed {
         return Err(eyre!("Invalid state exists on DL queue: {}", job.status.to_string()));
+    }
+    // We assume that a Failure status wil only show up if the message is sent twice from a queue
+    // Can return silently because it's already been processed.
+    else if job.status == JobStatus::Failed {
+        return Ok(());
     }
 
     metadata.insert("last_job_status".to_string(), job.status.to_string());

--- a/crates/orchestrator/src/jobs/mod.rs
+++ b/crates/orchestrator/src/jobs/mod.rs
@@ -174,13 +174,16 @@ pub async fn verify_job(id: Uuid) -> Result<()> {
 }
 
 /// Terminates the job and updates the status of the job in the DB.
-pub async fn terminate_job(id: Uuid) -> Result<()> {
+pub async fn handle_job_failure(id: Uuid) -> Result<()> {
     let config = config().await;
-    let job = get_job(id).await?;
+
+    let mut job = get_job(id).await?.clone();
     let mut metadata = job.metadata.clone();
     metadata.insert("last_job_status".to_string(), job.status.to_string());
-    config.database().update_metadata(&job, metadata).await?;
-    config.database().update_job_status(&job, JobStatus::Failed).await?;
+    job.metadata = metadata;
+    job.status = JobStatus::Failed;
+
+    config.database().update_job(&job).await?;
 
     Ok(())
 }

--- a/crates/orchestrator/src/jobs/mod.rs
+++ b/crates/orchestrator/src/jobs/mod.rs
@@ -188,7 +188,8 @@ pub async fn handle_job_failure(id: Uuid) -> Result<()> {
     let mut metadata = job.metadata.clone();
 
     if job.status == JobStatus::Completed {
-        return Err(eyre!("Invalid state exists on DL queue: {}", job.status.to_string()));
+        log::error!("Invalid state exists on DL queue: {}", job.status.to_string());
+        return Ok(());
     }
     // We assume that a Failure status wil only show up if the message is sent twice from a queue
     // Can return silently because it's already been processed.

--- a/crates/orchestrator/src/jobs/types.rs
+++ b/crates/orchestrator/src/jobs/types.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt};
 
 use color_eyre::eyre::eyre;
 use color_eyre::Result;
@@ -99,6 +99,22 @@ pub enum JobStatus {
     VerificationTimeout,
     /// The job failed processing
     VerificationFailed(String),
+    /// The job failed completing
+    Failed,
+}
+
+impl fmt::Display for JobStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            JobStatus::Created => write!(f, "Created"),
+            JobStatus::LockedForProcessing => write!(f, "Locked for Processing"),
+            JobStatus::PendingVerification => write!(f, "Pending Verification"),
+            JobStatus::Completed => write!(f, "Completed"),
+            JobStatus::VerificationTimeout => write!(f, "Verification Timeout"),
+            JobStatus::VerificationFailed(reason) => write!(f, "Verification Failed: {}", reason),
+            JobStatus::Failed => write!(f, "Failed"),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/crates/orchestrator/src/jobs/types.rs
+++ b/crates/orchestrator/src/jobs/types.rs
@@ -111,11 +111,10 @@ impl fmt::Display for JobStatus {
             JobStatus::PendingVerification => write!(f, "Pending Verification"),
             JobStatus::Completed => write!(f, "Completed"),
             JobStatus::VerificationTimeout => write!(f, "Verification Timeout"),
-            JobStatus::VerificationFailed(reason) => write!(f, "Verification Failed: {}", reason),
+            JobStatus::VerificationFailed => write!(f, "Verification Failed"),
             JobStatus::Failed => write!(f, "Failed"),
         }
     }
-    VerificationFailed,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/crates/orchestrator/src/queue/job_queue.rs
+++ b/crates/orchestrator/src/queue/job_queue.rs
@@ -12,10 +12,10 @@ use uuid::Uuid;
 use crate::config::config;
 use crate::jobs::{handle_job_failure, process_job, verify_job};
 
-const JOB_PROCESSING_QUEUE: &str = "madara_orchestrator_job_processing_queue";
-const JOB_VERIFICATION_QUEUE: &str = "madara_orchestrator_job_verification_queue";
+pub const JOB_PROCESSING_QUEUE: &str = "madara_orchestrator_job_processing_queue";
+pub const JOB_VERIFICATION_QUEUE: &str = "madara_orchestrator_job_verification_queue";
 // Below is the Data Letter Queue for the the above two jobs.
-const JOB_HANDLE_FAILURE_QUEUE: &str = "madara_orchestrator_job_handle_failure_queue";
+pub const JOB_HANDLE_FAILURE_QUEUE: &str = "madara_orchestrator_job_handle_failure_queue";
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct JobQueueMessage {

--- a/crates/orchestrator/src/queue/job_queue.rs
+++ b/crates/orchestrator/src/queue/job_queue.rs
@@ -10,11 +10,12 @@ use tracing::log;
 use uuid::Uuid;
 
 use crate::config::config;
-use crate::jobs::{process_job, terminate_job, verify_job};
+use crate::jobs::{handle_job_failure, process_job, verify_job};
 
 const JOB_PROCESSING_QUEUE: &str = "madara_orchestrator_job_processing_queue";
 const JOB_VERIFICATION_QUEUE: &str = "madara_orchestrator_job_verification_queue";
-const JOB_TERMINATION_QUEUE: &str = "madara_orchestrator_job_termination_queue";
+// Below is the Data Letter Queue for the the above two jobs.
+const JOB_HANDLE_FAILURE_QUEUE: &str = "madara_orchestrator_job_handle_failure_queue";
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct JobQueueMessage {
@@ -69,35 +70,25 @@ where
     Ok(())
 }
 
+macro_rules! spawn_consumer {
+    ($queue_type :expr, $handler : expr) => {
+        tokio::spawn(async move {
+            loop {
+                match consume_job_from_queue($queue_type, $handler).await {
+                    Ok(_) => {}
+                    Err(e) => log::error!("Failed to consume from queue {:?}. Error: {:?}", $queue_type, e),
+                }
+                sleep(Duration::from_secs(1)).await;
+            }
+        });
+    };
+}
+
 pub async fn init_consumers() -> Result<()> {
-    // TODO: figure out a way to generalize this
-    tokio::spawn(async move {
-        loop {
-            match consume_job_from_queue(JOB_PROCESSING_QUEUE.to_string(), process_job).await {
-                Ok(_) => {}
-                Err(e) => log::error!("Failed to consume from queue {:?}. Error: {:?}", JOB_PROCESSING_QUEUE, e),
-            }
-            sleep(Duration::from_secs(1)).await;
-        }
-    });
-    tokio::spawn(async move {
-        loop {
-            match consume_job_from_queue(JOB_VERIFICATION_QUEUE.to_string(), verify_job).await {
-                Ok(_) => {}
-                Err(e) => log::error!("Failed to consume from queue {:?}. Error: {:?}", JOB_VERIFICATION_QUEUE, e),
-            }
-            sleep(Duration::from_secs(1)).await;
-        }
-    });
-    tokio::spawn(async move {
-        loop {
-            match consume_job_from_queue(JOB_TERMINATION_QUEUE.to_string(), terminate_job).await {
-                Ok(_) => {}
-                Err(e) => log::error!("Failed to consume from queue {:?}. Error: {:?}", JOB_TERMINATION_QUEUE, e),
-            }
-            sleep(Duration::from_secs(1)).await;
-        }
-    });
+    spawn_consumer!(JOB_PROCESSING_QUEUE.to_string(), process_job);
+    spawn_consumer!(JOB_VERIFICATION_QUEUE.to_string(), verify_job);
+    spawn_consumer!(JOB_HANDLE_FAILURE_QUEUE.to_string(), handle_job_failure);
+
     Ok(())
 }
 

--- a/crates/orchestrator/src/tests/config.rs
+++ b/crates/orchestrator/src/tests/config.rs
@@ -18,6 +18,7 @@ use crate::database::{Database, DatabaseConfig};
 use crate::queue::sqs::SqsQueue;
 use crate::queue::QueueProvider;
 
+use super::common::drop_database;
 use httpmock::MockServer;
 // Inspiration : https://rust-unofficial.github.io/patterns/patterns/creational/builder.html
 // TestConfigBuilder allows to heavily customise the global configs based on the test's requirement.
@@ -131,6 +132,8 @@ impl TestConfigBuilder {
             self.queue.unwrap(),
             self.storage.unwrap(),
         );
+
+        drop_database().await.unwrap();
 
         config_force_init(config).await;
 

--- a/crates/orchestrator/src/tests/database/mod.rs
+++ b/crates/orchestrator/src/tests/database/mod.rs
@@ -51,7 +51,7 @@ async fn test_database_create_job() -> color_eyre::Result<()> {
 // Test Util Functions
 // ==========================================
 
-fn build_job_item(job_type: JobType, job_status: JobStatus, internal_id: u64) -> JobItem {
+pub fn build_job_item(job_type: JobType, job_status: JobStatus, internal_id: u64) -> JobItem {
     JobItem {
         id: Uuid::new_v4(),
         internal_id: internal_id.to_string(),

--- a/crates/orchestrator/src/tests/jobs/mod.rs
+++ b/crates/orchestrator/src/tests/jobs/mod.rs
@@ -3,7 +3,6 @@ use crate::config::config;
 use crate::jobs::handle_job_failure;
 use crate::jobs::types::JobType;
 use crate::{jobs::types::JobStatus, tests::config::TestConfigBuilder};
-use color_eyre::eyre::eyre;
 use rstest::rstest;
 use std::str::FromStr;
 #[cfg(test)]
@@ -27,7 +26,6 @@ async fn create_job_fails_works_new_job() {
     todo!()
 }
 
-#[cfg(test)]
 impl FromStr for JobStatus {
     type Err = String;
 
@@ -45,7 +43,6 @@ impl FromStr for JobStatus {
     }
 }
 
-#[cfg(test)]
 impl FromStr for JobType {
     type Err = String;
 
@@ -111,9 +108,10 @@ async fn handle_job_failure_job_status_typical_works(#[case] job_type: JobType, 
 
 #[rstest]
 // code should panic here, how can completed move to dl queue ?
-#[case("DataSubmission", "Completed")]
+#[case("DataSubmission")]
 #[tokio::test]
-async fn handle_job_failure__job_status_completed_fails(#[case] job_type: JobType, #[case] job_status: JobStatus) {
+async fn handle_job_failure__job_status_completed_works(#[case] job_type: JobType) {
+    let job_status = JobStatus::Completed;
     TestConfigBuilder::new().build().await;
     let internal_id = 1;
 
@@ -128,16 +126,12 @@ async fn handle_job_failure__job_status_completed_fails(#[case] job_type: JobTyp
     database_client.create_job(job.clone()).await.unwrap();
 
     // calling handle_job_failure
-    let response = handle_job_failure(job_id).await;
+    handle_job_failure(job_id).await.expect("Test call to handle_job_failure should have passed.");
 
-    match response {
-        Ok(()) => {
-            panic!("Test call to handle_job_failure should not have passed");
-        }
-        Err(err) => {
-            // Should only fail for Completed case, anything else : raise error
-            let expected = eyre!("Invalid state exists on DL queue: {}", job_status);
-            assert_eq!(err.to_string(), expected.to_string());
-        }
+    // The completed job status on db is untouched.
+    let job_fetched_result = config.database().get_job_by_id(job_id).await.expect("Unable to fetch Job Data");
+
+    if let Some(job_fetched) = job_fetched_result {
+        assert_eq!(job_fetched.status, JobStatus::Completed);
     }
 }

--- a/crates/orchestrator/src/tests/jobs/mod.rs
+++ b/crates/orchestrator/src/tests/jobs/mod.rs
@@ -68,11 +68,12 @@ impl FromStr for JobType {
 #[case("SnosRun", "PendingVerification")]
 #[case("ProofCreation", "LockedForProcessing")]
 #[case("ProofRegistration", "Created")]
+#[case("DataSubmission", "Failed")]
 #[case("StateTransition", "Completed")]
 #[case("ProofCreation", "VerificationTimeout")]
 #[case("DataSubmission", "VerificationFailed()")]
 #[tokio::test]
-async fn test_handle_job_failure(#[case] job_type: JobType, #[case] error_type: JobStatus) -> color_eyre::Result<()> {
+async fn test_handle_job_failure(#[case] job_type: JobType, #[case] job_status: JobStatus) -> color_eyre::Result<()> {
     use color_eyre::eyre::eyre;
 
     TestConfigBuilder::new().build().await;
@@ -84,8 +85,15 @@ async fn test_handle_job_failure(#[case] job_type: JobType, #[case] error_type: 
     let database_client = config.database();
 
     // create a job
-    let job = build_job_item(job_type, error_type, internal_id);
+    let mut job = build_job_item(job_type.clone(), job_status.clone(), internal_id);
     let job_id = job.id;
+
+    // if testcase is for Failure, add last_job_status to job's metadata
+    if job_status == JobStatus::Failed {
+        let mut metadata = job.metadata.clone();
+        metadata.insert("last_job_status".to_string(), "VerificationTimeout".to_string());
+        job.metadata = metadata;
+    }
 
     // feeding the job to DB
     database_client.create_job(job.clone()).await.unwrap();

--- a/crates/orchestrator/src/tests/jobs/mod.rs
+++ b/crates/orchestrator/src/tests/jobs/mod.rs
@@ -3,8 +3,9 @@ use crate::config::config;
 use crate::jobs::handle_job_failure;
 use crate::jobs::types::JobType;
 use crate::{jobs::types::JobStatus, tests::config::TestConfigBuilder};
+use color_eyre::eyre::eyre;
 use rstest::rstest;
-
+use std::str::FromStr;
 #[cfg(test)]
 pub mod da_job;
 
@@ -17,17 +18,16 @@ pub mod state_update_job;
 #[rstest]
 #[tokio::test]
 async fn create_job_fails_job_already_exists() {
-    // TODO
+    todo!()
 }
 
 #[rstest]
 #[tokio::test]
 async fn create_job_fails_works_new_job() {
-    // TODO
+    todo!()
 }
 
-use std::str::FromStr;
-
+#[cfg(test)]
 impl FromStr for JobStatus {
     type Err = String;
 
@@ -38,16 +38,14 @@ impl FromStr for JobStatus {
             "PendingVerification" => Ok(JobStatus::PendingVerification),
             "Completed" => Ok(JobStatus::Completed),
             "VerificationTimeout" => Ok(JobStatus::VerificationTimeout),
+            "VerificationFailed" => Ok(JobStatus::VerificationFailed),
             "Failed" => Ok(JobStatus::Failed),
-            s if s.starts_with("VerificationFailed(") && s.ends_with(')') => {
-                let reason = s[19..s.len() - 1].to_string();
-                Ok(JobStatus::VerificationFailed(reason))
-            }
             _ => Err(format!("Invalid job status: {}", s)),
         }
     }
 }
 
+#[cfg(test)]
 impl FromStr for JobType {
     type Err = String;
 
@@ -64,21 +62,11 @@ impl FromStr for JobType {
 }
 
 #[rstest]
-#[case("DataSubmission", "Completed")] // code should panic here, how can completed move to dl queue ?
 #[case("SnosRun", "PendingVerification")]
-#[case("ProofCreation", "LockedForProcessing")]
-#[case("ProofRegistration", "Created")]
 #[case("DataSubmission", "Failed")]
-#[case("StateTransition", "Completed")]
-#[case("ProofCreation", "VerificationTimeout")]
-#[case("DataSubmission", "VerificationFailed()")]
 #[tokio::test]
-async fn test_handle_job_failure(#[case] job_type: JobType, #[case] job_status: JobStatus) -> color_eyre::Result<()> {
-    use color_eyre::eyre::eyre;
-
+async fn handle_job_failure_job_status_typical_works(#[case] job_type: JobType, #[case] job_status: JobStatus) {
     TestConfigBuilder::new().build().await;
-    dotenvy::from_filename("../.env.test")?;
-
     let internal_id = 1;
 
     let config = config().await;
@@ -88,7 +76,7 @@ async fn test_handle_job_failure(#[case] job_type: JobType, #[case] job_status: 
     let mut job = build_job_item(job_type.clone(), job_status.clone(), internal_id);
     let job_id = job.id;
 
-    // if testcase is for Failure, add last_job_status to job's metadata
+    // if test case is for Failure, add last_job_status to job's metadata
     if job_status == JobStatus::Failed {
         let mut metadata = job.metadata.clone();
         metadata.insert("last_job_status".to_string(), "VerificationTimeout".to_string());
@@ -104,7 +92,7 @@ async fn test_handle_job_failure(#[case] job_type: JobType, #[case] job_status: 
     match response {
         Ok(()) => {
             // check job in db
-            let job = config.database().get_job_by_id(job_id).await?;
+            let job = config.database().get_job_by_id(job_id).await.expect("Unable to fetch Job Data");
 
             if let Some(job_item) = job {
                 // check if job status is Failure
@@ -113,15 +101,43 @@ async fn test_handle_job_failure(#[case] job_type: JobType, #[case] job_status: 
                 assert_ne!(None, job_item.metadata.get("last_job_status"));
 
                 println!("Handle Job Failure for ID {} was handled successfully", job_id);
-            } else {
-                return Err(eyre!("Unable to fetch Job Data"));
             }
         }
         Err(err) => {
-            let expected = eyre!("Invalid state exists on DL queue: Completed");
+            panic!("Test case should have passed: {} ", err);
+        }
+    }
+}
+
+#[rstest]
+// code should panic here, how can completed move to dl queue ?
+#[case("DataSubmission", "Completed")]
+#[tokio::test]
+async fn handle_job_failure__job_status_completed_fails(#[case] job_type: JobType, #[case] job_status: JobStatus) {
+    TestConfigBuilder::new().build().await;
+    let internal_id = 1;
+
+    let config = config().await;
+    let database_client = config.database();
+
+    // create a job
+    let job = build_job_item(job_type.clone(), job_status.clone(), internal_id);
+    let job_id = job.id;
+
+    // feeding the job to DB
+    database_client.create_job(job.clone()).await.unwrap();
+
+    // calling handle_job_failure
+    let response = handle_job_failure(job_id).await;
+
+    match response {
+        Ok(()) => {
+            panic!("Test call to handle_job_failure should not have passed");
+        }
+        Err(err) => {
             // Should only fail for Completed case, anything else : raise error
+            let expected = eyre!("Invalid state exists on DL queue: {}", job_status);
             assert_eq!(err.to_string(), expected.to_string());
         }
     }
-    Ok(())
 }

--- a/crates/orchestrator/src/tests/jobs/mod.rs
+++ b/crates/orchestrator/src/tests/jobs/mod.rs
@@ -1,3 +1,8 @@
+use super::database::build_job_item;
+use crate::config::config;
+use crate::jobs::handle_job_failure;
+use crate::jobs::types::JobType;
+use crate::{jobs::types::JobStatus, tests::config::TestConfigBuilder};
 use rstest::rstest;
 
 #[cfg(test)]
@@ -19,4 +24,96 @@ async fn create_job_fails_job_already_exists() {
 #[tokio::test]
 async fn create_job_fails_works_new_job() {
     // TODO
+}
+
+use std::str::FromStr;
+
+impl FromStr for JobStatus {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Created" => Ok(JobStatus::Created),
+            "LockedForProcessing" => Ok(JobStatus::LockedForProcessing),
+            "PendingVerification" => Ok(JobStatus::PendingVerification),
+            "Completed" => Ok(JobStatus::Completed),
+            "VerificationTimeout" => Ok(JobStatus::VerificationTimeout),
+            "Failed" => Ok(JobStatus::Failed),
+            s if s.starts_with("VerificationFailed(") && s.ends_with(')') => {
+                let reason = s[19..s.len() - 1].to_string();
+                Ok(JobStatus::VerificationFailed(reason))
+            }
+            _ => Err(format!("Invalid job status: {}", s)),
+        }
+    }
+}
+
+impl FromStr for JobType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "SnosRun" => Ok(JobType::SnosRun),
+            "DataSubmission" => Ok(JobType::DataSubmission),
+            "ProofCreation" => Ok(JobType::ProofCreation),
+            "ProofRegistration" => Ok(JobType::ProofRegistration),
+            "StateTransition" => Ok(JobType::StateTransition),
+            _ => Err(format!("Invalid job type: {}", s)),
+        }
+    }
+}
+
+#[rstest]
+#[case("DataSubmission", "Completed")] // code should panic here, how can completed move to dl queue ?
+#[case("SnosRun", "PendingVerification")]
+#[case("ProofCreation", "LockedForProcessing")]
+#[case("ProofRegistration", "Created")]
+#[case("StateTransition", "Completed")]
+#[case("ProofCreation", "VerificationTimeout")]
+#[case("DataSubmission", "VerificationFailed()")]
+#[tokio::test]
+async fn test_handle_job_failure(#[case] job_type: JobType, #[case] error_type: JobStatus) -> color_eyre::Result<()> {
+    use color_eyre::eyre::eyre;
+
+    TestConfigBuilder::new().build().await;
+    dotenvy::from_filename("../.env.test")?;
+
+    let internal_id = 1;
+
+    let config = config().await;
+    let database_client = config.database();
+
+    // create a job
+    let job = build_job_item(job_type, error_type, internal_id);
+    let job_id = job.id;
+
+    // feeding the job to DB
+    database_client.create_job(job.clone()).await.unwrap();
+
+    // calling handle_job_failure
+    let response = handle_job_failure(job_id).await;
+
+    match response {
+        Ok(()) => {
+            // check job in db
+            let job = config.database().get_job_by_id(job_id).await?;
+
+            if let Some(job_item) = job {
+                // check if job status is Failure
+                assert_eq!(job_item.status, JobStatus::Failed);
+                // check if job metadata has `last_job_status`
+                assert_ne!(None, job_item.metadata.get("last_job_status"));
+
+                println!("Handle Job Failure for ID {} was handled successfully", job_id);
+            } else {
+                return Err(eyre!("Unable to fetch Job Data"));
+            }
+        }
+        Err(err) => {
+            let expected = eyre!("Invalid state exists on DL queue: Completed");
+            // Should only fail for Completed case, anything else : raise error
+            assert_eq!(err.to_string(), expected.to_string());
+        }
+    }
+    Ok(())
 }

--- a/crates/orchestrator/src/tests/jobs/mod.rs
+++ b/crates/orchestrator/src/tests/jobs/mod.rs
@@ -95,8 +95,7 @@ async fn handle_job_failure_job_status_typical_works(#[case] job_type: JobType, 
                 // check if job status is Failure
                 assert_eq!(job_item.status, JobStatus::Failed);
                 // check if job metadata has `last_job_status`
-                assert_ne!(None, job_item.metadata.get("last_job_status"));
-
+                assert!(job_item.metadata.get("last_job_status").is_some());
                 println!("Handle Job Failure for ID {} was handled successfully", job_id);
             }
         }

--- a/crates/orchestrator/src/tests/jobs/mod.rs
+++ b/crates/orchestrator/src/tests/jobs/mod.rs
@@ -1,10 +1,12 @@
-use super::database::build_job_item;
+use rstest::rstest;
+
 use crate::config::config;
 use crate::jobs::handle_job_failure;
 use crate::jobs::types::JobType;
 use crate::{jobs::types::JobStatus, tests::config::TestConfigBuilder};
-use rstest::rstest;
-use std::str::FromStr;
+
+use super::database::build_job_item;
+
 #[cfg(test)]
 pub mod da_job;
 
@@ -26,96 +28,43 @@ async fn create_job_fails_works_new_job() {
     todo!()
 }
 
-impl FromStr for JobStatus {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "Created" => Ok(JobStatus::Created),
-            "LockedForProcessing" => Ok(JobStatus::LockedForProcessing),
-            "PendingVerification" => Ok(JobStatus::PendingVerification),
-            "Completed" => Ok(JobStatus::Completed),
-            "VerificationTimeout" => Ok(JobStatus::VerificationTimeout),
-            "VerificationFailed" => Ok(JobStatus::VerificationFailed),
-            "Failed" => Ok(JobStatus::Failed),
-            _ => Err(format!("Invalid job status: {}", s)),
-        }
-    }
-}
-
-impl FromStr for JobType {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "SnosRun" => Ok(JobType::SnosRun),
-            "DataSubmission" => Ok(JobType::DataSubmission),
-            "ProofCreation" => Ok(JobType::ProofCreation),
-            "ProofRegistration" => Ok(JobType::ProofRegistration),
-            "StateTransition" => Ok(JobType::StateTransition),
-            _ => Err(format!("Invalid job type: {}", s)),
-        }
-    }
-}
-
 #[rstest]
-#[case("SnosRun", "PendingVerification")]
-#[case("DataSubmission", "Failed")]
+#[case(JobType::SnosRun, JobStatus::Failed)]
 #[tokio::test]
-async fn handle_job_failure_job_status_typical_works(#[case] job_type: JobType, #[case] job_status: JobStatus) {
+async fn handle_job_failure_with_failed_job_status_works(#[case] job_type: JobType, #[case] job_status: JobStatus) {
     TestConfigBuilder::new().build().await;
-    let internal_id = 1;
-
     let config = config().await;
     let database_client = config.database();
+    let internal_id = 1;
 
-    // create a job
-    let mut job = build_job_item(job_type.clone(), job_status.clone(), internal_id);
-    let job_id = job.id;
+    // create a job, with already available "last_job_status"
+    let mut job_expected = build_job_item(job_type.clone(), job_status.clone(), internal_id);
+    let mut job_metadata = job_expected.metadata.clone();
+    job_metadata.insert("last_job_status".to_string(), JobStatus::PendingVerification.to_string());
+    job_expected.metadata = job_metadata.clone();
 
-    // if test case is for Failure, add last_job_status to job's metadata
-    if job_status == JobStatus::Failed {
-        let mut metadata = job.metadata.clone();
-        metadata.insert("last_job_status".to_string(), "VerificationTimeout".to_string());
-        job.metadata = metadata;
-    }
+    let job_id = job_expected.id;
 
     // feeding the job to DB
-    database_client.create_job(job.clone()).await.unwrap();
+    database_client.create_job(job_expected.clone()).await.unwrap();
 
     // calling handle_job_failure
-    let response = handle_job_failure(job_id).await;
+    handle_job_failure(job_id).await.expect("handle_job_failure failed to run");
 
-    match response {
-        Ok(()) => {
-            // check job in db
-            let job = config.database().get_job_by_id(job_id).await.expect("Unable to fetch Job Data");
+    let job_fetched = config.database().get_job_by_id(job_id).await.expect("Unable to fetch Job Data").unwrap();
 
-            if let Some(job_item) = job {
-                // check if job status is Failure
-                assert_eq!(job_item.status, JobStatus::Failed);
-                // check if job metadata has `last_job_status`
-                assert!(job_item.metadata.get("last_job_status").is_some());
-                println!("Handle Job Failure for ID {} was handled successfully", job_id);
-            }
-        }
-        Err(err) => {
-            panic!("Test case should have passed: {} ", err);
-        }
-    }
+    assert_eq!(job_fetched, job_expected);
 }
 
 #[rstest]
-// code should panic here, how can completed move to dl queue ?
-#[case("DataSubmission")]
+#[case::pending_verification(JobType::SnosRun, JobStatus::PendingVerification)]
+#[case::verification_timout(JobType::SnosRun, JobStatus::VerificationTimeout)]
 #[tokio::test]
-async fn handle_job_failure__job_status_completed_works(#[case] job_type: JobType) {
-    let job_status = JobStatus::Completed;
+async fn handle_job_failure_with_correct_job_status_works(#[case] job_type: JobType, #[case] job_status: JobStatus) {
     TestConfigBuilder::new().build().await;
-    let internal_id = 1;
-
     let config = config().await;
     let database_client = config.database();
+    let internal_id = 1;
 
     // create a job
     let job = build_job_item(job_type.clone(), job_status.clone(), internal_id);
@@ -125,12 +74,43 @@ async fn handle_job_failure__job_status_completed_works(#[case] job_type: JobTyp
     database_client.create_job(job.clone()).await.unwrap();
 
     // calling handle_job_failure
+    handle_job_failure(job_id).await.expect("handle_job_failure failed to run");
+
+    let job_fetched = config.database().get_job_by_id(job_id).await.expect("Unable to fetch Job Data").unwrap();
+
+    // creating expected output
+    let mut job_expected = job.clone();
+    let mut job_metadata = job_expected.metadata.clone();
+    job_metadata.insert("last_job_status".to_string(), job_status.to_string());
+    job_expected.metadata = job_metadata.clone();
+    job_expected.status = JobStatus::Failed;
+
+    assert_eq!(job_fetched, job_expected);
+}
+
+#[rstest]
+#[case(JobType::DataSubmission)]
+#[tokio::test]
+async fn handle_job_failure_job_status_completed_works(#[case] job_type: JobType) {
+    let job_status = JobStatus::Completed;
+
+    TestConfigBuilder::new().build().await;
+    let config = config().await;
+    let database_client = config.database();
+    let internal_id = 1;
+
+    // create a job
+    let job_expected = build_job_item(job_type.clone(), job_status.clone(), internal_id);
+    let job_id = job_expected.id;
+
+    // feeding the job to DB
+    database_client.create_job(job_expected.clone()).await.unwrap();
+
+    // calling handle_job_failure
     handle_job_failure(job_id).await.expect("Test call to handle_job_failure should have passed.");
 
     // The completed job status on db is untouched.
-    let job_fetched_result = config.database().get_job_by_id(job_id).await.expect("Unable to fetch Job Data");
+    let job_fetched = config.database().get_job_by_id(job_id).await.expect("Unable to fetch Job Data").unwrap();
 
-    if let Some(job_fetched) = job_fetched_result {
-        assert_eq!(job_fetched.status, JobStatus::Completed);
-    }
+    assert_eq!(job_fetched, job_expected);
 }


### PR DESCRIPTION
This PR resolves Issue #55 .

- Implemented Dead Letter Queue handler.
- Adds `last_job_status` to job metadata.
- Runs and Tests needs to spin up appropriate queues.
- Test for `handle_job_failure`.