### PR TITLE
move mongodb serde behind feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Added
 
+- moved mongodb serde behind feature flag
 - implemented DA worker.
 - Function to calculate the kzg proof of x_0.
 - Tests for updating the state.

--- a/crates/orchestrator/src/jobs/types.rs
+++ b/crates/orchestrator/src/jobs/types.rs
@@ -4,6 +4,7 @@ use color_eyre::eyre::eyre;
 use color_eyre::Result;
 use da_client_interface::DaVerificationStatus;
 // TODO: job types shouldn't depend on mongodb
+#[cfg(feature = "with_mongodb")]
 use mongodb::bson::serde_helpers::uuid_1_as_binary;
 use serde::{Deserialize, Serialize};
 use settlement_client_interface::SettlementVerificationStatus;
@@ -104,7 +105,7 @@ pub enum JobStatus {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct JobItem {
     /// an uuid to identify a job
-    #[serde(with = "uuid_1_as_binary")]
+    #[cfg_attr(feature = "with_mongodb", serde(with = "uuid_1_as_binary"))]
     pub id: Uuid,
     /// a meaningful id used to track a job internally, ex: block_no, txn_hash
     pub internal_id: String,


### PR DESCRIPTION
Solves #40. All mongodb usage should be behind a feature flag.