### PR TITLE
Chore : Renaming Tests & No test returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `.env` file requires two more variables which are queue urls for processing
   and verification.
 - Shifted Unit tests to test folder for DA job.
+- Tests following Test conventions.
 
 ## Removed
 

--- a/crates/orchestrator/src/jobs/da_job/mod.rs
+++ b/crates/orchestrator/src/jobs/da_job/mod.rs
@@ -373,7 +373,7 @@ pub mod test {
     #[case(false, 1, 0, "18446744073709551616")]
     #[case(false, 0, 6, "6")]
     #[case(true, 1, 0, "340282366920938463481821351505477763072")]
-    fn test_da_word(
+    fn da_word_typical_works(
         #[case] class_flag: bool,
         #[case] new_nonce: u64,
         #[case] num_changes: u64,
@@ -409,7 +409,7 @@ pub mod test {
         "src/tests/jobs/da_job/test_data/nonces/640641.txt"
     )]
     #[tokio::test]
-    async fn test_state_update_to_blob_data(
+    async fn state_update_to_blob_data_typical_works(
         #[case] block_no: u64,
         #[case] state_update_file_path: &str,
         #[case] file_path: &str,
@@ -470,7 +470,7 @@ pub mod test {
     #[case("src/tests/jobs/da_job/test_data/test_blob/640644.txt")]
     #[case("src/tests/jobs/da_job/test_data/test_blob/640646.txt")]
     #[case("src/tests/jobs/da_job/test_data/test_blob/640647.txt")]
-    fn test_fft_transformation(#[case] file_to_check: &str) {
+    fn fft_transformation_typical_works(#[case] file_to_check: &str) {
         // parsing the blob hex to the bigUints
 
         use crate::jobs::da_job::fft_transformation;
@@ -489,7 +489,7 @@ pub mod test {
     /// Verifies that the original data matches the deserialized data.
     /// Ensures the integrity and correctness of bincode's (de)serialization.
     #[rstest]
-    fn test_bincode() {
+    fn bincode_basic_works() {
         let data = vec![vec![1, 2], vec![3, 4]];
 
         let serialize_data = bincode::serialize(&data).unwrap();

--- a/crates/orchestrator/src/jobs/mod.rs
+++ b/crates/orchestrator/src/jobs/mod.rs
@@ -217,11 +217,11 @@ fn get_u64_from_metadata(metadata: &HashMap<String, String>, key: &str) -> Resul
 mod tests {
     use super::*;
 
-    mod test_incremement_key_in_metadata {
+    mod increment_key_in_metadata {
         use super::*;
 
         #[test]
-        fn key_does_not_exist() {
+        fn key_does_not_exist_works() {
             let metadata = HashMap::new();
             let key = "test_key";
             let updated_metadata = increment_key_in_metadata(&metadata, key).unwrap();
@@ -229,7 +229,7 @@ mod tests {
         }
 
         #[test]
-        fn key_exists_with_numeric_value() {
+        fn key_exists_with_numeric_value_works() {
             let mut metadata = HashMap::new();
             metadata.insert("test_key".to_string(), "41".to_string());
             let key = "test_key";
@@ -238,7 +238,7 @@ mod tests {
         }
 
         #[test]
-        fn key_exists_with_non_numeric_value() {
+        fn key_exists_with_non_numeric_value_fails() {
             let mut metadata = HashMap::new();
             metadata.insert("test_key".to_string(), "not_a_number".to_string());
             let key = "test_key";
@@ -247,7 +247,7 @@ mod tests {
         }
 
         #[test]
-        fn key_exists_with_max_u64_value() {
+        fn key_exists_with_max_u64_value_fails() {
             let mut metadata = HashMap::new();
             metadata.insert("test_key".to_string(), u64::MAX.to_string());
             let key = "test_key";
@@ -256,11 +256,11 @@ mod tests {
         }
     }
 
-    mod test_get_u64_from_metadata {
+    mod get_u64_from_metadata {
         use super::*;
 
         #[test]
-        fn key_exists_with_valid_u64_value() {
+        fn key_exists_with_valid_u64_value_works() {
             let mut metadata = HashMap::new();
             metadata.insert("key1".to_string(), "12345".to_string());
             let result = get_u64_from_metadata(&metadata, "key1").unwrap();
@@ -268,7 +268,7 @@ mod tests {
         }
 
         #[test]
-        fn key_exists_with_invalid_value() {
+        fn key_exists_with_invalid_value_fails() {
             let mut metadata = HashMap::new();
             metadata.insert("key2".to_string(), "not_a_number".to_string());
             let result = get_u64_from_metadata(&metadata, "key2");
@@ -276,7 +276,7 @@ mod tests {
         }
 
         #[test]
-        fn key_does_not_exist() {
+        fn key_does_not_exist_works() {
             let metadata = HashMap::<String, String>::new();
             let result = get_u64_from_metadata(&metadata, "key3").unwrap();
             assert_eq!(result, 0);

--- a/crates/orchestrator/src/tests/data_storage/mod.rs
+++ b/crates/orchestrator/src/tests/data_storage/mod.rs
@@ -13,10 +13,10 @@ use utils::env_utils::get_env_var_or_panic;
 /// Dependencies: `color_eyre`, `dotenvy`, `rstest`, `tokio`, `serde_json`.
 #[rstest]
 #[tokio::test]
-async fn test_put_and_get_data_s3() -> color_eyre::Result<()> {
+async fn put_and_get_data_s3_typical_works() {
     TestConfigBuilder::new().build().await;
 
-    dotenvy::from_filename("../.env.test")?;
+    dotenvy::from_filename("../.env.test").expect("Unable to read file.");
 
     let config = S3LocalStackConfig::new_from_env();
     let s3_client = AWSS3::new(AWSS3ConfigType::WithEndpoint(config)).await;
@@ -27,7 +27,7 @@ async fn test_put_and_get_data_s3() -> color_eyre::Result<()> {
             "body" : "hello world. hello world."
         }
     );
-    let json_bytes = serde_json::to_vec(&mock_data)?;
+    let json_bytes = serde_json::to_vec(&mock_data).expect("Unable to serialize json.");
     let key = "test_data.txt";
 
     // putting test data on key : "test_data.txt"
@@ -35,9 +35,7 @@ async fn test_put_and_get_data_s3() -> color_eyre::Result<()> {
 
     // getting the data from key : "test_data.txt"
     let data = s3_client.get_data(key).await.expect("Unable to get the data from the bucket.");
-    let received_json: serde_json::Value = serde_json::from_slice(&data)?;
+    let received_json: serde_json::Value = serde_json::from_slice(&data).expect("Unable to serialize json.");
 
     assert_eq!(received_json, mock_data);
-
-    Ok(())
 }

--- a/crates/orchestrator/src/tests/database/mod.rs
+++ b/crates/orchestrator/src/tests/database/mod.rs
@@ -8,9 +8,8 @@ use uuid::Uuid;
 
 #[rstest]
 #[tokio::test]
-async fn test_database_connection() -> color_eyre::Result<()> {
-    TestConfigBuilder::new().build().await;
-    Ok(())
+async fn database_connection_typical_works() {
+    let _ = TestConfigBuilder::new().build().await;
 }
 
 #[fixture]
@@ -22,7 +21,7 @@ async fn get_config() -> Guard<Arc<Config>> {
 /// Creates 3 jobs and asserts them.
 #[rstest]
 #[tokio::test]
-async fn test_database_create_job(#[future] get_config: Guard<Arc<Config>>) -> color_eyre::Result<()> {
+async fn database_create_job_typical_works(#[future] get_config: Guard<Arc<Config>>) {
     TestConfigBuilder::new().build().await;
     let config = get_config.await;
     let database_client = config.database();
@@ -47,12 +46,7 @@ async fn test_database_create_job(#[future] get_config: Guard<Arc<Config>>) -> c
     assert_eq!(get_job_1, job_vec[0].clone());
     assert_eq!(get_job_2, job_vec[1].clone());
     assert_eq!(get_job_3, job_vec[2].clone());
-
-    Ok(())
 }
-
-// Test Util Functions
-// ==========================================
 
 fn build_job_item(job_type: JobType, job_status: JobStatus, internal_id: u64) -> JobItem {
     JobItem {

--- a/crates/orchestrator/src/tests/jobs/da_job/mod.rs
+++ b/crates/orchestrator/src/tests/jobs/da_job/mod.rs
@@ -26,7 +26,7 @@ use uuid::Uuid;
     110
 )]
 #[tokio::test]
-async fn test_da_job_process_job_failure_on_small_blob_size(
+async fn da_job_process_job_on_small_blob_size_fails(
     #[case] state_update_file: String,
     #[case] nonces_file: String,
     #[case] internal_id: String,
@@ -95,7 +95,7 @@ async fn test_da_job_process_job_failure_on_small_blob_size(
 /// Asserts correct behavior by comparing the received and expected error messages.
 #[rstest]
 #[tokio::test]
-async fn test_da_job_process_job_failure_on_pending_block() {
+async fn da_job_process_job_on_pending_block_fails() {
     let server = TestConfigBuilder::new().build().await;
     let config = config().await;
     let internal_id = "1";
@@ -171,7 +171,7 @@ async fn test_da_job_process_job_failure_on_pending_block() {
     "638353"
 )]
 #[tokio::test]
-async fn test_da_job_process_job_success(
+async fn da_job_process_job_typical_success(
     #[case] state_update_file: String,
     #[case] nonces_file: String,
     #[case] internal_id: String,

--- a/crates/orchestrator/src/tests/jobs/proving_job/mod.rs
+++ b/crates/orchestrator/src/tests/jobs/proving_job/mod.rs
@@ -14,7 +14,7 @@ use crate::jobs::Job;
 
 #[rstest]
 #[tokio::test]
-async fn test_create_job() {
+async fn proving_create_job_typical_works() {
     let config = init_config(None, None, None, None, None, None, None).await;
     let job = ProvingJob
         .create_job(
@@ -37,7 +37,7 @@ async fn test_create_job() {
 
 #[rstest]
 #[tokio::test]
-async fn test_verify_job(#[from(default_job_item)] mut job_item: JobItem) {
+async fn proving_verify_job_typical_works(#[from(default_job_item)] mut job_item: JobItem) {
     let mut prover_client = MockProverClient::new();
     prover_client.expect_get_task_status().times(1).returning(|_| Ok(TaskStatus::Succeeded));
 
@@ -47,7 +47,7 @@ async fn test_verify_job(#[from(default_job_item)] mut job_item: JobItem) {
 
 #[rstest]
 #[tokio::test]
-async fn test_process_job() {
+async fn proving_process_job_typical_works() {
     let server = MockServer::start();
 
     let mut prover_client = MockProverClient::new();

--- a/crates/orchestrator/src/tests/jobs/state_update_job/mod.rs
+++ b/crates/orchestrator/src/tests/jobs/state_update_job/mod.rs
@@ -40,7 +40,7 @@ pub const X_0_FILE_NAME: &str = "x_0.txt";
 #[rstest]
 #[should_panic(expected = "Could not find current attempt number.")]
 #[tokio::test]
-async fn test_process_job_attempt_not_present_fails() {
+async fn state_update_process_job_attempt_not_present_fails() {
     TestConfigBuilder::new().build().await;
 
     let mut job = default_job_item();
@@ -53,7 +53,7 @@ async fn test_process_job_attempt_not_present_fails() {
 #[case(None, String::from("651053,651054,651055"), 0)]
 #[case(Some(651054), String::from("651053,651054,651055"), 1)]
 #[tokio::test]
-async fn test_process_job_works(
+async fn state_update_process_job_typical_works(
     #[case] failed_block_number: Option<u64>,
     #[case] blocks_to_process: String,
     #[case] processing_start_index: u8,
@@ -115,7 +115,7 @@ async fn test_process_job_works(
 
 #[rstest]
 #[tokio::test]
-async fn test_create_job() {
+async fn state_update_create_job_works() {
     let config = init_config(None, None, None, None, None, None, None).await;
 
     let job = StateUpdateJob.create_job(&config, String::from("0"), HashMap::default()).await;
@@ -133,7 +133,7 @@ async fn test_create_job() {
 
 #[rstest]
 #[tokio::test]
-async fn test_process_job() {
+async fn state_update_process_job_with_mock_server_works() {
     let server = MockServer::start();
     let mut settlement_client = MockSettlementClient::new();
     let mut storage_client = MockDataStorage::new();
@@ -214,7 +214,10 @@ async fn test_process_job() {
 #[case(String::from("651052, 651052, 651053, 651053"), "Duplicated block numbers")]
 #[case(String::from(""), "settle list is not correctly formatted")]
 #[tokio::test]
-async fn test_process_job_invalid_inputs(#[case] block_numbers_to_settle: String, #[case] expected_error: &str) {
+async fn state_update_process_job_with_invalid_inputs_fails(
+    #[case] block_numbers_to_settle: String,
+    #[case] expected_error: &str,
+) {
     let server = MockServer::start();
     let settlement_client = MockSettlementClient::new();
     let config = init_config(
@@ -249,7 +252,7 @@ async fn test_process_job_invalid_inputs(#[case] block_numbers_to_settle: String
 #[rstest]
 #[tokio::test]
 #[should_panic(expected = "Gap detected between the first block to settle and the last one settle")]
-async fn test_process_job_invalid_input_gap() {
+async fn state_update_process_job_invalid_input_gap_panics() {
     let server = MockServer::start();
     let mut settlement_client = MockSettlementClient::new();
 

--- a/crates/orchestrator/src/tests/queue/mod.rs
+++ b/crates/orchestrator/src/tests/queue/mod.rs
@@ -3,5 +3,6 @@ use rstest::*;
 #[rstest]
 #[tokio::test]
 async fn test_queue() {
+    todo!("Tests for queue not implemented yet.")
     // TODO: write test case
 }

--- a/crates/orchestrator/src/tests/server/mod.rs
+++ b/crates/orchestrator/src/tests/server/mod.rs
@@ -34,7 +34,7 @@ pub async fn setup_server() -> SocketAddr {
 
 #[rstest]
 #[tokio::test]
-async fn test_health_endpoint(#[future] setup_server: SocketAddr) {
+async fn health_endpoint_works(#[future] setup_server: SocketAddr) {
     let addr = setup_server.await;
 
     let client = hyper::Client::new();
@@ -53,6 +53,6 @@ async fn test_health_endpoint(#[future] setup_server: SocketAddr) {
 
 #[rstest]
 #[tokio::test]
-async fn test_init_consumer() {
+async fn init_consumer_works() {
     assert!(init_consumers().await.is_ok());
 }

--- a/crates/orchestrator/src/tests/workers/mod.rs
+++ b/crates/orchestrator/src/tests/workers/mod.rs
@@ -2,5 +2,5 @@
 pub mod proving;
 #[cfg(test)]
 pub mod snos;
-mod update_state;
+mod state_update;
 mod utils;

--- a/crates/orchestrator/src/tests/workers/proving/mod.rs
+++ b/crates/orchestrator/src/tests/workers/proving/mod.rs
@@ -1,4 +1,3 @@
-use std::error::Error;
 use std::sync::Arc;
 
 use da_client_interface::MockDaClient;
@@ -22,7 +21,7 @@ use crate::workers::proving::ProvingWorker;
 #[case(true)]
 #[case(false)]
 #[tokio::test]
-async fn test_proving_worker(#[case] incomplete_runs: bool) -> Result<(), Box<dyn Error>> {
+async fn proving_worker_with_and_without_incomplete_runs_works(#[case] incomplete_runs: bool) {
     let server = MockServer::start();
     let da_client = MockDaClient::new();
     let mut db = MockDatabase::new();
@@ -107,9 +106,7 @@ async fn test_proving_worker(#[case] incomplete_runs: bool) -> Result<(), Box<dy
     }
 
     let proving_worker = ProvingWorker {};
-    proving_worker.run_worker().await?;
-
-    Ok(())
+    proving_worker.run_worker().await.expect("Unable to run proving worker");
 }
 
 use crate::workers::Worker;

--- a/crates/orchestrator/src/tests/workers/snos/mod.rs
+++ b/crates/orchestrator/src/tests/workers/snos/mod.rs
@@ -1,4 +1,3 @@
-use std::error::Error;
 use std::sync::Arc;
 
 use da_client_interface::MockDaClient;
@@ -24,7 +23,7 @@ use crate::workers::Worker;
 #[case(false)]
 #[case(true)]
 #[tokio::test]
-async fn test_snos_worker(#[case] db_val: bool) -> Result<(), Box<dyn Error>> {
+async fn snos_worker_with_and_without_incomplete_runs_works(#[case] db_val: bool) {
     let server = MockServer::start();
     let da_client = MockDaClient::new();
     let mut db = MockDatabase::new();
@@ -107,9 +106,7 @@ async fn test_snos_worker(#[case] db_val: bool) -> Result<(), Box<dyn Error>> {
     });
 
     let snos_worker = SnosWorker {};
-    snos_worker.run_worker().await?;
+    snos_worker.run_worker().await.expect("Unable to run snos worker.");
 
     rpc_block_call_mock.assert();
-
-    Ok(())
 }

--- a/crates/orchestrator/src/tests/workers/state_update/mod.rs
+++ b/crates/orchestrator/src/tests/workers/state_update/mod.rs
@@ -1,4 +1,3 @@
-use std::error::Error;
 use std::sync::Arc;
 
 use da_client_interface::MockDaClient;
@@ -24,10 +23,10 @@ use crate::workers::Worker;
 #[case(false, 0)]
 #[case(true, 5)]
 #[tokio::test]
-async fn test_update_state_worker(
+async fn state_update_worker_with_and_without_incomplete_runs_works(
     #[case] last_successful_job_exists: bool,
     #[case] number_of_processed_jobs: usize,
-) -> Result<(), Box<dyn Error>> {
+) {
     let server = MockServer::start();
     let da_client = MockDaClient::new();
     let mut db = MockDatabase::new();
@@ -112,7 +111,5 @@ async fn test_update_state_worker(
     config_force_init(config).await;
 
     let update_state_worker = UpdateStateWorker {};
-    update_state_worker.run_worker().await?;
-
-    Ok(())
+    update_state_worker.run_worker().await.expect("Unable to run state update worker");
 }

--- a/crates/prover-services/gps-fact-checker/src/fact_info.rs
+++ b/crates/prover-services/gps-fact-checker/src/fact_info.rs
@@ -86,7 +86,7 @@ mod tests {
     use super::get_fact_info;
 
     #[test]
-    fn test_fact_info() {
+    fn fact_info_typical_works() {
         // Generated using the get_fact.py script
         let expected_fact = "0xca15503f02f8406b599cb220879e842394f5cf2cef753f3ee430647b5981b782";
         let cairo_pie_path: PathBuf =


### PR DESCRIPTION
# This PR ensures that tests follow correct test conventions.

## Conventions : 
### Test name : `method_name_state_under_test_expected_behaviour`.
### No test function should have a return statement, there's no benefit in getting a test to return any value.