### PR TITLE
update: better alert impl.

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -26,7 +26,6 @@ SQS_WORKER_TRIGGER_QUEUE_URL="http://sqs.us-east-1.localhost.localstack.cloud:45
 
 ##### SNS #####
 ALERTS="sns"
-AWS_SNS_REGION="us-east-1"
 AWS_SNS_ARN="arn:aws:sns:us-east-1:000000000000:madara-orchestrator-arn"
 AWS_SNS_ARN_NAME="madara-orchestrator-arn"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Changed
 
+- Better TestConfigBuilder, with sync config clients.
+- Drilled Config, removing dirty global reads.
 - refactor AWS config usage and clean .env files
 - GitHub's coverage CI yml file for localstack and db testing.
 - Orchestrator :Moved TestConfigBuilder to `config.rs` in tests folder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Changed
 
+- AWS config built from TestConfigBuilder.
 - Better TestConfigBuilder, with sync config clients.
 - Drilled Config, removing dirty global reads.
 - refactor AWS config usage and clean .env files

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,12 +1074,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
-name = "arc-swap"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
-
-[[package]]
 name = "ark-ec"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6392,7 +6386,6 @@ name = "orchestrator"
 version = "0.1.0"
 dependencies = [
  "alloy 0.2.1",
- "arc-swap",
  "assert_matches",
  "async-std",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ url = { version = "2.5.0", features = ["serde"] }
 uuid = { version = "1.7.0", features = ["v4", "serde"] }
 httpmock = { version = "0.7.0", features = ["remote"] }
 num-bigint = { version = "0.4.4" }
-arc-swap = { version = "1.7.1" }
 num-traits = "0.2"
 lazy_static = "1.4.0"
 stark_evm_adapter = "0.1.1"

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -13,7 +13,6 @@ path = "src/main.rs"
 
 [dependencies]
 alloy = { workspace = true }
-arc-swap = { workspace = true }
 assert_matches = "1.5.0"
 async-std = "1.12.0"
 async-trait = { workspace = true }

--- a/crates/orchestrator/src/alerts/aws_sns/mod.rs
+++ b/crates/orchestrator/src/alerts/aws_sns/mod.rs
@@ -13,12 +13,6 @@ impl AWSSNS {
     pub async fn new(config: &SdkConfig) -> Self {
         AWSSNS { client: Client::new(config) }
     }
-
-    /// To create a new SNS client from the environment variables
-    pub async fn new_from_env() -> Self {
-        let config = aws_config::from_env().load().await;
-        AWSSNS { client: Client::new(&config) }
-    }
 }
 
 #[async_trait]

--- a/crates/orchestrator/src/alerts/aws_sns/mod.rs
+++ b/crates/orchestrator/src/alerts/aws_sns/mod.rs
@@ -1,6 +1,6 @@
 use crate::alerts::Alerts;
 use async_trait::async_trait;
-use aws_sdk_sns::config::Region;
+use aws_config::SdkConfig;
 use aws_sdk_sns::Client;
 use utils::env_utils::get_env_var_or_panic;
 
@@ -10,9 +10,13 @@ pub struct AWSSNS {
 
 impl AWSSNS {
     /// To create a new SNS client
-    pub async fn new() -> Self {
-        let sns_region = get_env_var_or_panic("AWS_SNS_REGION");
-        let config = aws_config::from_env().region(Region::new(sns_region)).load().await;
+    pub async fn new(config: &SdkConfig) -> Self {
+        AWSSNS { client: Client::new(config) }
+    }
+
+    /// To create a new SNS client from the environment variables
+    pub async fn new_from_env() -> Self {
+        let config = aws_config::from_env().load().await;
         AWSSNS { client: Client::new(&config) }
     }
 }

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -1,27 +1,26 @@
 use std::sync::Arc;
 
-use crate::alerts::aws_sns::AWSSNS;
-use crate::alerts::Alerts;
-use crate::data_storage::aws_s3::config::AWSS3Config;
-use crate::data_storage::aws_s3::AWSS3;
-use crate::data_storage::{DataStorage, DataStorageConfig};
-use arc_swap::{ArcSwap, Guard};
 use aws_config::SdkConfig;
-use da_client_interface::{DaClient, DaConfig};
 use dotenvy::dotenv;
+use starknet::providers::jsonrpc::HttpTransport;
+use starknet::providers::{JsonRpcClient, Url};
+
+use da_client_interface::{DaClient, DaConfig};
 use ethereum_da_client::config::EthereumDaConfig;
 use ethereum_settlement_client::EthereumSettlementClient;
 use prover_client_interface::ProverClient;
 use settlement_client_interface::SettlementClient;
 use sharp_service::SharpProverService;
-use starknet::providers::jsonrpc::HttpTransport;
-use starknet::providers::{JsonRpcClient, Url};
 use starknet_settlement_client::StarknetSettlementClient;
-use tokio::sync::OnceCell;
 use utils::env_utils::get_env_var_or_panic;
 use utils::settings::default::DefaultSettingsProvider;
 use utils::settings::SettingsProvider;
 
+use crate::alerts::aws_sns::AWSSNS;
+use crate::alerts::Alerts;
+use crate::data_storage::aws_s3::config::AWSS3Config;
+use crate::data_storage::aws_s3::AWSS3;
+use crate::data_storage::{DataStorage, DataStorageConfig};
 use crate::database::mongodb::config::MongoDbConfig;
 use crate::database::mongodb::MongoDb;
 use crate::database::{Database, DatabaseConfig};
@@ -50,7 +49,7 @@ pub struct Config {
 }
 
 /// Initializes the app config
-pub async fn init_config() -> Config {
+pub async fn init_config() -> Arc<Config> {
     dotenv().ok();
 
     // init starknet client
@@ -77,10 +76,9 @@ pub async fn init_config() -> Config {
     let prover_client = build_prover_service(&settings_provider);
 
     let storage_client = build_storage_client(&aws_config).await;
-
     let alerts_client = build_alert_client().await;
 
-    Config::new(
+    Arc::new(Config::new(
         Arc::new(provider),
         da_client,
         prover_client,
@@ -89,7 +87,7 @@ pub async fn init_config() -> Config {
         queue,
         storage_client,
         alerts_client,
-    )
+    ))
 }
 
 impl Config {
@@ -154,27 +152,27 @@ impl Config {
 /// We are using `ArcSwap` as it allow us to replace the new `Config` with
 /// a new one which is required when running test cases. This approach was
 /// inspired from here - https://github.com/matklad/once_cell/issues/127
-pub static CONFIG: OnceCell<ArcSwap<Config>> = OnceCell::const_new();
+// pub static CONFIG: OnceCell<ArcSwap<Config>> = OnceCell::const_new();
 
 /// Returns the app config. Initializes if not already done.
-pub async fn config() -> Guard<Arc<Config>> {
-    let cfg = CONFIG.get_or_init(|| async { ArcSwap::from_pointee(init_config().await) }).await;
-    cfg.load()
-}
+// pub async fn config() -> Guard<Arc<Config>> {
+//     let cfg = CONFIG.get_or_init(|| async { ArcSwap::from_pointee(init_config().await) }).await;
+//     cfg.load()
+// }
 
 /// OnceCell only allows us to initialize the config once and that's how it should be on production.
 /// However, when running tests, we often want to reinitialize because we want to clear the DB and
 /// set it up again for reuse in new tests. By calling `config_force_init` we replace the already
 /// stored config inside `ArcSwap` with the new configuration and pool settings.
-#[cfg(test)]
-pub async fn config_force_init(config: Config) {
-    match CONFIG.get() {
-        Some(arc) => arc.store(Arc::new(config)),
-        None => {
-            CONFIG.get_or_init(|| async { ArcSwap::from_pointee(config) }).await;
-        }
-    }
-}
+// #[cfg(test)]
+// pub async fn config_force_init(config: Config) {
+//     match CONFIG.get() {
+//         Some(arc) => arc.store(Arc::new(config)),
+//         None => {
+//             CONFIG.get_or_init(|| async { ArcSwap::from_pointee(config) }).await;
+//         }
+//     }
+// }
 
 /// Builds the DA client based on the environment variable DA_LAYER
 pub async fn build_da_client() -> Box<dyn DaClient + Send + Sync> {

--- a/crates/orchestrator/src/jobs/da_job/mod.rs
+++ b/crates/orchestrator/src/jobs/da_job/mod.rs
@@ -14,10 +14,11 @@ use thiserror::Error;
 use tracing::log;
 use uuid::Uuid;
 
-use super::types::{JobItem, JobStatus, JobType, JobVerificationStatus};
-use super::{Job, JobError, OtherError};
 use crate::config::Config;
 use crate::constants::BLOB_DATA_FILE_NAME;
+
+use super::types::{JobItem, JobStatus, JobType, JobVerificationStatus};
+use super::{Job, JobError, OtherError};
 
 lazy_static! {
     /// EIP-4844 BLS12-381 modulus.
@@ -371,17 +372,13 @@ fn da_word(class_flag: bool, nonce_change: Option<FieldElement>, num_changes: u6
 #[cfg(test)]
 
 pub mod test {
-    use crate::jobs::da_job::da_word;
     use std::fs;
     use std::fs::File;
     use std::io::Read;
     use std::sync::Arc;
 
-    use crate::data_storage::MockDataStorage;
-    use crate::tests::config::TestConfigBuilder;
     use ::serde::{Deserialize, Serialize};
     use color_eyre::Result;
-    use da_client_interface::MockDaClient;
     use httpmock::prelude::*;
     use majin_blob_core::blob;
     use majin_blob_types::serde;
@@ -392,6 +389,12 @@ pub mod test {
     use starknet::providers::JsonRpcClient;
     use starknet_core::types::{FieldElement, StateUpdate};
     use url::Url;
+
+    use da_client_interface::MockDaClient;
+
+    use crate::data_storage::MockDataStorage;
+    use crate::jobs::da_job::da_word;
+    use crate::tests::config::{ClientType, ClientValue, TestConfigBuilder};
 
     /// Tests `da_word` function with various inputs for class flag, new nonce, and number of changes.
     /// Verifies that `da_word` produces the correct FieldElement based on the provided parameters.
@@ -463,9 +466,9 @@ pub mod test {
 
         // mock block number (madara) : 5
         let services = TestConfigBuilder::new()
-            .mock_starknet_client(Arc::new(provider))
-            .mock_da_client(Box::new(da_client))
-            .mock_storage_client(Box::new(storage_client))
+            .configure_starknet_client(ClientValue::MockBySelf(ClientType::StarknetClient(Arc::new(provider))))
+            .configure_da_client(ClientValue::MockBySelf(ClientType::DaClient(Arc::new(Box::new(da_client)))))
+            .configure_storage_client(ClientValue::MockBySelf(ClientType::Storage(Arc::new(Box::new(storage_client)))))
             .build()
             .await;
 

--- a/crates/orchestrator/src/jobs/da_job/mod.rs
+++ b/crates/orchestrator/src/jobs/da_job/mod.rs
@@ -375,7 +375,6 @@ pub mod test {
     use std::fs;
     use std::fs::File;
     use std::io::Read;
-    use std::sync::Arc;
 
     use ::serde::{Deserialize, Serialize};
     use color_eyre::Result;
@@ -394,7 +393,6 @@ pub mod test {
 
     use crate::data_storage::MockDataStorage;
     use crate::jobs::da_job::da_word;
-    use crate::tests::config::{ClientType, ClientValue, TestConfigBuilder};
 
     /// Tests `da_word` function with various inputs for class flag, new nonce, and number of changes.
     /// Verifies that `da_word` produces the correct FieldElement based on the provided parameters.
@@ -447,7 +445,10 @@ pub mod test {
         #[case] file_path: &str,
         #[case] nonce_file_path: &str,
     ) {
-        use crate::jobs::da_job::{convert_to_biguint, state_update_to_blob_data};
+        use crate::{
+            jobs::da_job::{convert_to_biguint, state_update_to_blob_data},
+            tests::config::TestConfigBuilder,
+        };
 
         let server = MockServer::start();
         let mut da_client = MockDaClient::new();
@@ -466,9 +467,9 @@ pub mod test {
 
         // mock block number (madara) : 5
         let services = TestConfigBuilder::new()
-            .configure_starknet_client(ClientValue::MockBySelf(ClientType::StarknetClient(Arc::new(provider))))
-            .configure_da_client(ClientValue::MockBySelf(ClientType::DaClient(Arc::new(Box::new(da_client)))))
-            .configure_storage_client(ClientValue::MockBySelf(ClientType::Storage(Arc::new(Box::new(storage_client)))))
+            .configure_starknet_client(provider.into())
+            .configure_da_client(da_client.into())
+            .configure_storage_client(storage_client.into())
             .build()
             .await;
 

--- a/crates/orchestrator/src/jobs/da_job/mod.rs
+++ b/crates/orchestrator/src/jobs/da_job/mod.rs
@@ -496,27 +496,27 @@ pub mod test {
     /// Verifies the correctness of FFT and IFFT transformations by ensuring round-trip consistency.
     /// Parses the original blob data, recovers it using IFFT, and re-applies FFT.
     /// Asserts that the transformed data matches the original pre-IFFT data, ensuring integrity.
-    #[rstest]
-    #[case("src/tests/jobs/da_job/test_data/test_blob/638353.txt")]
-    #[case("src/tests/jobs/da_job/test_data/test_blob/631861.txt")]
-    #[case("src/tests/jobs/da_job/test_data/test_blob/639404.txt")]
-    #[case("src/tests/jobs/da_job/test_data/test_blob/640641.txt")]
-    #[case("src/tests/jobs/da_job/test_data/test_blob/640644.txt")]
-    #[case("src/tests/jobs/da_job/test_data/test_blob/640646.txt")]
-    #[case("src/tests/jobs/da_job/test_data/test_blob/640647.txt")]
-    fn test_fft_transformation(#[case] file_to_check: &str) {
-        // parsing the blob hex to the bigUints
+    // #[rstest]
+    // #[case("src/tests/jobs/da_job/test_data/test_blob/638353.txt")]
+    // #[case("src/tests/jobs/da_job/test_data/test_blob/631861.txt")]
+    // #[case("src/tests/jobs/da_job/test_data/test_blob/639404.txt")]
+    // #[case("src/tests/jobs/da_job/test_data/test_blob/640641.txt")]
+    // #[case("src/tests/jobs/da_job/test_data/test_blob/640644.txt")]
+    // #[case("src/tests/jobs/da_job/test_data/test_blob/640646.txt")]
+    // #[case("src/tests/jobs/da_job/test_data/test_blob/640647.txt")]
+    // fn test_fft_transformation(#[case] file_to_check: &str) {
+    //     // parsing the blob hex to the bigUints
 
-        use crate::jobs::da_job::fft_transformation;
-        let original_blob_data = serde::parse_file_to_blob_data(file_to_check);
-        // converting the data to its original format
-        let ifft_blob_data = blob::recover(original_blob_data.clone());
-        // applying the fft function again on the original format
-        let fft_blob_data = fft_transformation(ifft_blob_data);
+    //     use crate::jobs::da_job::fft_transformation;
+    //     let original_blob_data = serde::parse_file_to_blob_data(file_to_check);
+    //     // converting the data to its original format
+    //     let ifft_blob_data = blob::recover(original_blob_data.clone());
+    //     // applying the fft function again on the original format
+    //     let fft_blob_data = fft_transformation(ifft_blob_data);
 
-        // ideally the data after fft transformation and the data before ifft should be same.
-        assert_eq!(fft_blob_data, original_blob_data);
-    }
+    //     // ideally the data after fft transformation and the data before ifft should be same.
+    //     assert_eq!(fft_blob_data, original_blob_data);
+    // }
 
     /// Tests the serialization and deserialization process using bincode.
     /// Serializes a nested vector of integers and then deserializes it back.

--- a/crates/orchestrator/src/jobs/da_job/mod.rs
+++ b/crates/orchestrator/src/jobs/da_job/mod.rs
@@ -496,27 +496,27 @@ pub mod test {
     /// Verifies the correctness of FFT and IFFT transformations by ensuring round-trip consistency.
     /// Parses the original blob data, recovers it using IFFT, and re-applies FFT.
     /// Asserts that the transformed data matches the original pre-IFFT data, ensuring integrity.
-    // #[rstest]
-    // #[case("src/tests/jobs/da_job/test_data/test_blob/638353.txt")]
-    // #[case("src/tests/jobs/da_job/test_data/test_blob/631861.txt")]
-    // #[case("src/tests/jobs/da_job/test_data/test_blob/639404.txt")]
-    // #[case("src/tests/jobs/da_job/test_data/test_blob/640641.txt")]
-    // #[case("src/tests/jobs/da_job/test_data/test_blob/640644.txt")]
-    // #[case("src/tests/jobs/da_job/test_data/test_blob/640646.txt")]
-    // #[case("src/tests/jobs/da_job/test_data/test_blob/640647.txt")]
-    // fn test_fft_transformation(#[case] file_to_check: &str) {
-    //     // parsing the blob hex to the bigUints
+    #[rstest]
+    #[case("src/tests/jobs/da_job/test_data/test_blob/638353.txt")]
+    #[case("src/tests/jobs/da_job/test_data/test_blob/631861.txt")]
+    #[case("src/tests/jobs/da_job/test_data/test_blob/639404.txt")]
+    #[case("src/tests/jobs/da_job/test_data/test_blob/640641.txt")]
+    #[case("src/tests/jobs/da_job/test_data/test_blob/640644.txt")]
+    #[case("src/tests/jobs/da_job/test_data/test_blob/640646.txt")]
+    #[case("src/tests/jobs/da_job/test_data/test_blob/640647.txt")]
+    fn test_fft_transformation(#[case] file_to_check: &str) {
+        // parsing the blob hex to the bigUints
 
-    //     use crate::jobs::da_job::fft_transformation;
-    //     let original_blob_data = serde::parse_file_to_blob_data(file_to_check);
-    //     // converting the data to its original format
-    //     let ifft_blob_data = blob::recover(original_blob_data.clone());
-    //     // applying the fft function again on the original format
-    //     let fft_blob_data = fft_transformation(ifft_blob_data);
+        use crate::jobs::da_job::fft_transformation;
+        let original_blob_data = serde::parse_file_to_blob_data(file_to_check);
+        // converting the data to its original format
+        let ifft_blob_data = blob::recover(original_blob_data.clone());
+        // applying the fft function again on the original format
+        let fft_blob_data = fft_transformation(ifft_blob_data);
 
-    //     // ideally the data after fft transformation and the data before ifft should be same.
-    //     assert_eq!(fft_blob_data, original_blob_data);
-    // }
+        // ideally the data after fft transformation and the data before ifft should be same.
+        assert_eq!(fft_blob_data, original_blob_data);
+    }
 
     /// Tests the serialization and deserialization process using bincode.
     /// Serializes a nested vector of integers and then deserializes it back.

--- a/crates/orchestrator/src/jobs/proving_job/mod.rs
+++ b/crates/orchestrator/src/jobs/proving_job/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use cairo_vm::vm::runners::cairo_pie::CairoPie;
@@ -34,7 +35,7 @@ pub struct ProvingJob;
 impl Job for ProvingJob {
     async fn create_job(
         &self,
-        _config: &Config,
+        _config: Arc<Config>,
         internal_id: String,
         metadata: HashMap<String, String>,
     ) -> Result<JobItem, JobError> {
@@ -49,7 +50,7 @@ impl Job for ProvingJob {
         })
     }
 
-    async fn process_job(&self, config: &Config, job: &mut JobItem) -> Result<String, JobError> {
+    async fn process_job(&self, config: Arc<Config>, job: &mut JobItem) -> Result<String, JobError> {
         // Cairo Pie path in s3 storage client
         let cairo_pie_path = job.internal_id.to_string() + "/pie.zip";
         let cairo_pie_file = config
@@ -70,7 +71,7 @@ impl Job for ProvingJob {
         Ok(external_id)
     }
 
-    async fn verify_job(&self, config: &Config, job: &mut JobItem) -> Result<JobVerificationStatus, JobError> {
+    async fn verify_job(&self, config: Arc<Config>, job: &mut JobItem) -> Result<JobVerificationStatus, JobError> {
         let task_id: String = job.external_id.unwrap_string().map_err(|e| JobError::Other(OtherError(e)))?.into();
         let task_status = config
             .prover_client()

--- a/crates/orchestrator/src/jobs/register_proof_job/mod.rs
+++ b/crates/orchestrator/src/jobs/register_proof_job/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use color_eyre::Result;
@@ -16,7 +17,7 @@ pub struct RegisterProofJob;
 impl Job for RegisterProofJob {
     async fn create_job(
         &self,
-        _config: &Config,
+        _config: Arc<Config>,
         internal_id: String,
         metadata: HashMap<String, String>,
     ) -> Result<JobItem, JobError> {
@@ -33,14 +34,14 @@ impl Job for RegisterProofJob {
         })
     }
 
-    async fn process_job(&self, _config: &Config, _job: &mut JobItem) -> Result<String, JobError> {
+    async fn process_job(&self, _config: Arc<Config>, _job: &mut JobItem) -> Result<String, JobError> {
         // Get proof from storage and submit on chain for verification
         // We need to implement a generic trait for this to support multiple
         // base layers
         todo!()
     }
 
-    async fn verify_job(&self, _config: &Config, _job: &mut JobItem) -> Result<JobVerificationStatus, JobError> {
+    async fn verify_job(&self, _config: Arc<Config>, _job: &mut JobItem) -> Result<JobVerificationStatus, JobError> {
         // verify that the proof transaction has been included on chain
         todo!()
     }

--- a/crates/orchestrator/src/jobs/snos_job/mod.rs
+++ b/crates/orchestrator/src/jobs/snos_job/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use color_eyre::Result;
@@ -16,7 +17,7 @@ pub struct SnosJob;
 impl Job for SnosJob {
     async fn create_job(
         &self,
-        _config: &Config,
+        _config: Arc<Config>,
         internal_id: String,
         metadata: HashMap<String, String>,
     ) -> Result<JobItem, JobError> {
@@ -31,14 +32,14 @@ impl Job for SnosJob {
         })
     }
 
-    async fn process_job(&self, _config: &Config, _job: &mut JobItem) -> Result<String, JobError> {
+    async fn process_job(&self, _config: Arc<Config>, _job: &mut JobItem) -> Result<String, JobError> {
         // 1. Fetch SNOS input data from Madara
         // 2. Import SNOS in Rust and execute it with the input data
         // 3. Store the received PIE in DB
         todo!()
     }
 
-    async fn verify_job(&self, _config: &Config, _job: &mut JobItem) -> Result<JobVerificationStatus, JobError> {
+    async fn verify_job(&self, _config: Arc<Config>, _job: &mut JobItem) -> Result<JobVerificationStatus, JobError> {
         // No need for verification as of now. If we later on decide to outsource SNOS run
         // to another service, verify_job can be used to poll on the status of the job
         todo!()

--- a/crates/orchestrator/src/jobs/state_update_job/utils.rs
+++ b/crates/orchestrator/src/jobs/state_update_job/utils.rs
@@ -1,10 +1,11 @@
-use crate::config::config;
+use std::sync::Arc;
+
+use crate::config::Config;
 use crate::constants::BLOB_DATA_FILE_NAME;
 use color_eyre::eyre::eyre;
 
 /// Fetching the blob data (stored in remote storage during DA job) for a particular block
-pub async fn fetch_blob_data_for_block(block_number: u64) -> color_eyre::Result<Vec<Vec<u8>>> {
-    let config = config().await;
+pub async fn fetch_blob_data_for_block(block_number: u64, config: Arc<Config>) -> color_eyre::Result<Vec<Vec<u8>>> {
     let storage_client = config.storage();
     let key = block_number.to_string() + "/" + BLOB_DATA_FILE_NAME;
     let blob_data = storage_client.get_data(&key).await?;

--- a/crates/orchestrator/src/main.rs
+++ b/crates/orchestrator/src/main.rs
@@ -1,5 +1,5 @@
 use dotenvy::dotenv;
-use orchestrator::config::config;
+use orchestrator::config::init_config;
 use orchestrator::queue::init_consumers;
 use orchestrator::routes::app_router;
 use utils::env_utils::get_env_var_or_default;
@@ -11,7 +11,8 @@ async fn main() {
     tracing_subscriber::fmt().with_max_level(tracing::Level::INFO).with_target(false).init();
 
     // initial config setup
-    config().await;
+    let config = init_config().await;
+
     let host = get_env_var_or_default("HOST", "127.0.0.1");
     let port = get_env_var_or_default("PORT", "3000").parse::<u16>().expect("PORT must be a u16");
     let address = format!("{}:{}", host, port);
@@ -19,7 +20,7 @@ async fn main() {
     let app = app_router();
 
     // init consumer
-    init_consumers().await.expect("Failed to init consumers");
+    init_consumers(config).await.expect("Failed to init consumers");
 
     tracing::info!("Listening on http://{}", address);
     axum::serve(listener, app).await.expect("Failed to start axum server");

--- a/crates/orchestrator/src/queue/job_queue.rs
+++ b/crates/orchestrator/src/queue/job_queue.rs
@@ -1,16 +1,24 @@
 use std::future::Future;
+use std::sync::Arc;
 use std::time::Duration;
 
 use color_eyre::eyre::Context;
 use color_eyre::Result as EyreResult;
 use omniqueue::{Delivery, QueueError};
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use tokio::time::sleep;
 use tracing::log;
 use uuid::Uuid;
 
-use crate::config::config;
+use crate::config::Config;
 use crate::jobs::{handle_job_failure, process_job, verify_job, JobError, OtherError};
+use crate::workers::data_submission_worker::DataSubmissionWorker;
+use crate::workers::proof_registration::ProofRegistrationWorker;
+use crate::workers::proving::ProvingWorker;
+use crate::workers::snos::SnosWorker;
+use crate::workers::update_state::UpdateStateWorker;
+use crate::workers::Worker;
 
 pub const JOB_PROCESSING_QUEUE: &str = "madara_orchestrator_job_processing_queue";
 pub const JOB_VERIFICATION_QUEUE: &str = "madara_orchestrator_job_verification_queue";
@@ -19,14 +27,6 @@ pub const JOB_HANDLE_FAILURE_QUEUE: &str = "madara_orchestrator_job_handle_failu
 
 // Queues for SNOS worker trigger listening
 pub const WORKER_TRIGGER_QUEUE: &str = "madara_orchestrator_worker_trigger_queue";
-
-use crate::workers::data_submission_worker::DataSubmissionWorker;
-use crate::workers::proof_registration::ProofRegistrationWorker;
-use crate::workers::proving::ProvingWorker;
-use crate::workers::snos::SnosWorker;
-use crate::workers::update_state::UpdateStateWorker;
-use crate::workers::Worker;
-use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum ConsumptionError {
@@ -67,23 +67,28 @@ enum DeliveryReturnType {
     NoMessage,
 }
 
-pub async fn add_job_to_process_queue(id: Uuid) -> EyreResult<()> {
+pub async fn add_job_to_process_queue(id: Uuid, config: Arc<Config>) -> EyreResult<()> {
     log::info!("Adding job with id {:?} to processing queue", id);
-    add_job_to_queue(id, JOB_PROCESSING_QUEUE.to_string(), None).await
+    add_job_to_queue(id, JOB_PROCESSING_QUEUE.to_string(), None, config).await
 }
 
-pub async fn add_job_to_verification_queue(id: Uuid, delay: Duration) -> EyreResult<()> {
+pub async fn add_job_to_verification_queue(id: Uuid, delay: Duration, config: Arc<Config>) -> EyreResult<()> {
     log::info!("Adding job with id {:?} to verification queue", id);
-    add_job_to_queue(id, JOB_VERIFICATION_QUEUE.to_string(), Some(delay)).await
+    add_job_to_queue(id, JOB_VERIFICATION_QUEUE.to_string(), Some(delay), config).await
 }
 
-pub async fn consume_job_from_queue<F, Fut>(queue: String, handler: F) -> Result<(), ConsumptionError>
+pub async fn consume_job_from_queue<F, Fut>(
+    queue: String,
+    handler: F,
+    config: Arc<Config>,
+) -> Result<(), ConsumptionError>
 where
-    F: FnOnce(Uuid) -> Fut,
+    F: FnOnce(Uuid, Arc<Config>) -> Fut,
     Fut: Future<Output = Result<(), JobError>>,
 {
     log::info!("Consuming from queue {:?}", queue);
-    let delivery = get_delivery_from_queue(&queue).await?;
+
+    let delivery = get_delivery_from_queue(&queue, config.clone()).await?;
 
     let message = match delivery {
         DeliveryReturnType::Message(message) => message,
@@ -93,7 +98,7 @@ where
     let job_message = parse_job_message(&message)?;
 
     if let Some(job_message) = job_message {
-        handle_job_message(job_message, message, handler).await?;
+        handle_job_message(job_message, message, handler, config).await?;
     }
 
     Ok(())
@@ -104,13 +109,14 @@ where
 pub async fn consume_worker_trigger_messages_from_queue<F, Fut>(
     queue: String,
     handler: F,
+    config: Arc<Config>,
 ) -> Result<(), ConsumptionError>
 where
-    F: FnOnce(Box<dyn Worker>) -> Fut,
+    F: FnOnce(Box<dyn Worker>, Arc<Config>) -> Fut,
     Fut: Future<Output = color_eyre::Result<()>>,
 {
     log::info!("Consuming from queue {:?}", queue);
-    let delivery = get_delivery_from_queue(&queue).await?;
+    let delivery = get_delivery_from_queue(&queue, config.clone()).await?;
 
     let message = match delivery {
         DeliveryReturnType::Message(message) => message,
@@ -120,7 +126,7 @@ where
     let job_message = parse_worker_message(&message)?;
 
     if let Some(job_message) = job_message {
-        handle_worker_message(job_message, message, handler).await?;
+        handle_worker_message(job_message, message, handler, config).await?;
     }
 
     Ok(())
@@ -144,14 +150,15 @@ async fn handle_job_message<F, Fut>(
     job_message: JobQueueMessage,
     message: Delivery,
     handler: F,
+    config: Arc<Config>,
 ) -> Result<(), ConsumptionError>
 where
-    F: FnOnce(Uuid) -> Fut,
+    F: FnOnce(Uuid, Arc<Config>) -> Fut,
     Fut: Future<Output = Result<(), JobError>>,
 {
     log::info!("Handling job with id {:?}", job_message.id);
 
-    match handler(job_message.id).await {
+    match handler(job_message.id, config.clone()).await {
         Ok(_) => {
             message
                 .ack()
@@ -163,8 +170,7 @@ where
         }
         Err(e) => {
             log::error!("Failed to handle job with id {:?}. Error: {:?}", job_message.id, e);
-            config()
-                .await
+            config
                 .alerts()
                 .send_alert_message(e.to_string())
                 .await
@@ -188,15 +194,16 @@ async fn handle_worker_message<F, Fut>(
     job_message: WorkerTriggerMessage,
     message: Delivery,
     handler: F,
+    config: Arc<Config>,
 ) -> Result<(), ConsumptionError>
 where
-    F: FnOnce(Box<dyn Worker>) -> Fut,
+    F: FnOnce(Box<dyn Worker>, Arc<Config>) -> Fut,
     Fut: Future<Output = color_eyre::Result<()>>,
 {
     log::info!("Handling worker trigger for worker type : {:?}", job_message.worker);
     let worker_handler = get_worker_handler_from_worker_trigger_type(job_message.worker.clone());
 
-    match handler(worker_handler).await {
+    match handler(worker_handler, config.clone()).await {
         Ok(_) => {
             message
                 .ack()
@@ -208,8 +215,7 @@ where
         }
         Err(e) => {
             log::error!("Failed to handle worker trigger {:?}. Error: {:?}", job_message.worker, e);
-            config()
-                .await
+            config
                 .alerts()
                 .send_alert_message(e.to_string())
                 .await
@@ -236,8 +242,8 @@ fn get_worker_handler_from_worker_trigger_type(worker_trigger_type: WorkerTrigge
 }
 
 /// To get the delivery from the message queue using the queue name
-async fn get_delivery_from_queue(queue: &str) -> Result<DeliveryReturnType, ConsumptionError> {
-    match config().await.queue().consume_message_from_queue(queue.to_string()).await {
+async fn get_delivery_from_queue(queue: &str, config: Arc<Config>) -> Result<DeliveryReturnType, ConsumptionError> {
+    match config.queue().consume_message_from_queue(queue.to_string()).await {
         Ok(d) => Ok(DeliveryReturnType::Message(d)),
         Err(QueueError::NoData) => Ok(DeliveryReturnType::NoMessage),
         Err(e) => Err(ConsumptionError::FailedToConsumeFromQueue { error_msg: e.to_string() }),
@@ -245,10 +251,11 @@ async fn get_delivery_from_queue(queue: &str) -> Result<DeliveryReturnType, Cons
 }
 
 macro_rules! spawn_consumer {
-    ($queue_type :expr, $handler : expr, $consume_function: expr) => {
+    ($queue_type :expr, $handler : expr, $consume_function: expr, $config :expr) => {
+        let config_clone = $config.clone();
         tokio::spawn(async move {
             loop {
-                match $consume_function($queue_type, $handler).await {
+                match $consume_function($queue_type, $handler, config_clone.clone()).await {
                     Ok(_) => {}
                     Err(e) => log::error!("Failed to consume from queue {:?}. Error: {:?}", $queue_type, e),
                 }
@@ -258,22 +265,21 @@ macro_rules! spawn_consumer {
     };
 }
 
-pub async fn init_consumers() -> Result<(), JobError> {
-    spawn_consumer!(JOB_PROCESSING_QUEUE.to_string(), process_job, consume_job_from_queue);
-    spawn_consumer!(JOB_VERIFICATION_QUEUE.to_string(), verify_job, consume_job_from_queue);
-    spawn_consumer!(JOB_HANDLE_FAILURE_QUEUE.to_string(), handle_job_failure, consume_job_from_queue);
-    spawn_consumer!(WORKER_TRIGGER_QUEUE.to_string(), spawn_worker, consume_worker_trigger_messages_from_queue);
+pub async fn init_consumers(config: Arc<Config>) -> Result<(), JobError> {
+    spawn_consumer!(JOB_PROCESSING_QUEUE.to_string(), process_job, consume_job_from_queue, config.clone());
+    spawn_consumer!(JOB_VERIFICATION_QUEUE.to_string(), verify_job, consume_job_from_queue, config.clone());
+    spawn_consumer!(JOB_HANDLE_FAILURE_QUEUE.to_string(), handle_job_failure, consume_job_from_queue, config.clone());
+    spawn_consumer!(WORKER_TRIGGER_QUEUE.to_string(), spawn_worker, consume_worker_trigger_messages_from_queue, config);
     Ok(())
 }
 
 /// To spawn the worker by passing the worker struct
-async fn spawn_worker(worker: Box<dyn Worker>) -> color_eyre::Result<()> {
-    worker.run_worker_if_enabled().await.expect("Error in running the worker.");
+async fn spawn_worker(worker: Box<dyn Worker>, config: Arc<Config>) -> color_eyre::Result<()> {
+    worker.run_worker_if_enabled(config).await.expect("Error in running the worker.");
     Ok(())
 }
 
-async fn add_job_to_queue(id: Uuid, queue: String, delay: Option<Duration>) -> EyreResult<()> {
-    let config = config().await;
+async fn add_job_to_queue(id: Uuid, queue: String, delay: Option<Duration>, config: Arc<Config>) -> EyreResult<()> {
     let message = JobQueueMessage { id };
     config.queue().send_message_to_queue(queue, serde_json::to_string(&message)?, delay).await?;
     Ok(())

--- a/crates/orchestrator/src/queue/mod.rs
+++ b/crates/orchestrator/src/queue/mod.rs
@@ -1,14 +1,14 @@
 pub mod job_queue;
 pub mod sqs;
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use color_eyre::Result as EyreResult;
 use mockall::automock;
 use omniqueue::{Delivery, QueueError};
 
-use crate::jobs::JobError;
+use crate::{config::Config, jobs::JobError};
 
 /// The QueueProvider trait is used to define the methods that a queue
 /// should implement to be used as a queue for the orchestrator. The
@@ -20,6 +20,6 @@ pub trait QueueProvider: Send + Sync {
     async fn consume_message_from_queue(&self, queue: String) -> std::result::Result<Delivery, QueueError>;
 }
 
-pub async fn init_consumers() -> Result<(), JobError> {
-    job_queue::init_consumers().await
+pub async fn init_consumers(config: Arc<Config>) -> Result<(), JobError> {
+    job_queue::init_consumers(config).await
 }

--- a/crates/orchestrator/src/tests/alerts/mod.rs
+++ b/crates/orchestrator/src/tests/alerts/mod.rs
@@ -20,7 +20,7 @@ async fn sns_alert_subscribe_to_topic_receive_alert_works() {
     let queue = sqs_client.create_queue().queue_name(SNS_ALERT_TEST_QUEUE).send().await.unwrap();
     let queue_url = queue.queue_url().unwrap();
 
-    let sns_client = get_sns_client().await;
+    let sns_client = get_sns_client(&services.aws_config).await;
 
     let queue_attributes =
         sqs_client.get_queue_attributes().queue_url(queue_url).attribute_names(QueueArn).send().await.unwrap();

--- a/crates/orchestrator/src/tests/alerts/mod.rs
+++ b/crates/orchestrator/src/tests/alerts/mod.rs
@@ -7,14 +7,14 @@ use tokio::time::sleep;
 use utils::env_utils::get_env_var_or_panic;
 
 use crate::tests::common::{get_sns_client, get_sqs_client};
-use crate::tests::config::TestConfigBuilder;
+use crate::tests::config::{ClientValue, TestConfigBuilder};
 
 pub const SNS_ALERT_TEST_QUEUE: &str = "orchestrator_sns_alert_testing_queue";
 
 #[rstest]
 #[tokio::test]
 async fn sns_alert_subscribe_to_topic_receive_alert_works() {
-    let services = TestConfigBuilder::new().build().await;
+    let services = TestConfigBuilder::new().configure_alerts(ClientValue::Actual).build().await;
 
     let sqs_client = get_sqs_client().await;
     let queue = sqs_client.create_queue().queue_name(SNS_ALERT_TEST_QUEUE).send().await.unwrap();

--- a/crates/orchestrator/src/tests/alerts/mod.rs
+++ b/crates/orchestrator/src/tests/alerts/mod.rs
@@ -1,25 +1,26 @@
-use crate::config::config;
-use crate::tests::common::{get_sns_client, get_sqs_client};
-use crate::tests::config::TestConfigBuilder;
+use std::time::Duration;
+
 use aws_sdk_sqs::types::QueueAttributeName::QueueArn;
 use rstest::rstest;
-use std::time::Duration;
 use tokio::time::sleep;
+
 use utils::env_utils::get_env_var_or_panic;
+
+use crate::tests::common::{get_sns_client, get_sqs_client};
+use crate::tests::config::TestConfigBuilder;
 
 pub const SNS_ALERT_TEST_QUEUE: &str = "orchestrator_sns_alert_testing_queue";
 
 #[rstest]
 #[tokio::test]
 async fn sns_alert_subscribe_to_topic_receive_alert_works() {
-    TestConfigBuilder::new().build().await;
+    let services = TestConfigBuilder::new().build().await;
 
     let sqs_client = get_sqs_client().await;
     let queue = sqs_client.create_queue().queue_name(SNS_ALERT_TEST_QUEUE).send().await.unwrap();
     let queue_url = queue.queue_url().unwrap();
 
     let sns_client = get_sns_client().await;
-    let config = config().await;
 
     let queue_attributes =
         sqs_client.get_queue_attributes().queue_url(queue_url).attribute_names(QueueArn).send().await.unwrap();
@@ -39,7 +40,7 @@ async fn sns_alert_subscribe_to_topic_receive_alert_works() {
     let message_to_send = "Hello World :)";
 
     // Getting sns client from the module
-    let alerts_client = config.alerts();
+    let alerts_client = services.config.alerts();
     // Sending the alert message
     alerts_client.send_alert_message(message_to_send.to_string()).await.unwrap();
 

--- a/crates/orchestrator/src/tests/common/mod.rs
+++ b/crates/orchestrator/src/tests/common/mod.rs
@@ -3,7 +3,7 @@ pub mod constants;
 use std::collections::HashMap;
 
 use ::uuid::Uuid;
-use aws_config::Region;
+use aws_config::{Region, SdkConfig};
 use aws_sdk_sns::error::SdkError;
 use aws_sdk_sns::operation::create_topic::CreateTopicError;
 use mongodb::Client;
@@ -43,16 +43,14 @@ pub fn custom_job_item(default_job_item: JobItem, #[default(String::from("0"))] 
     job_item
 }
 
-pub async fn create_sns_arn() -> Result<(), SdkError<CreateTopicError>> {
-    let sns_client = get_sns_client().await;
+pub async fn create_sns_arn(aws_config: &SdkConfig) -> Result<(), SdkError<CreateTopicError>> {
+    let sns_client = get_sns_client(aws_config).await;
     sns_client.create_topic().name(get_env_var_or_panic("AWS_SNS_ARN_NAME")).send().await?;
     Ok(())
 }
 
-pub async fn get_sns_client() -> aws_sdk_sns::client::Client {
-    let sns_region = get_env_var_or_panic("AWS_SNS_REGION");
-    let config = aws_config::from_env().region(Region::new(sns_region)).load().await;
-    aws_sdk_sns::Client::new(&config)
+pub async fn get_sns_client(aws_config: &SdkConfig) -> aws_sdk_sns::client::Client {
+    aws_sdk_sns::Client::new(aws_config)
 }
 
 pub async fn drop_database() -> color_eyre::Result<()> {

--- a/crates/orchestrator/src/tests/config.rs
+++ b/crates/orchestrator/src/tests/config.rs
@@ -4,41 +4,116 @@ use httpmock::MockServer;
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, Url};
 
-use da_client_interface::DaClient;
-use prover_client_interface::ProverClient;
-use settlement_client_interface::SettlementClient;
+use da_client_interface::{DaClient, MockDaClient};
+use prover_client_interface::{MockProverClient, ProverClient};
+use settlement_client_interface::{MockSettlementClient, SettlementClient};
 use utils::settings::default::DefaultSettingsProvider;
 
-use crate::alerts::Alerts;
-use crate::config::{build_alert_client, build_da_client, build_prover_service, build_settlement_client, Config};
+use crate::alerts::{Alerts, MockAlerts};
+use crate::config::{
+    build_alert_client, build_da_client, build_database_client, build_prover_service, build_queue_client,
+    build_settlement_client, build_storage_client, Config,
+};
 use crate::data_storage::{DataStorage, MockDataStorage};
 use crate::database::{Database, MockDatabase};
-use crate::queue::sqs::SqsQueue;
-use crate::queue::QueueProvider;
+use crate::queue::{MockQueueProvider, QueueProvider};
 use crate::tests::common::{create_sns_arn, create_sqs_queues, drop_database};
 
 // Inspiration : https://rust-unofficial.github.io/patterns/patterns/creational/builder.html
 // TestConfigBuilder allows to heavily customise the global configs based on the test's requirement.
 // Eg: We want to mock only the da client and leave rest to be as it is, use mock_da_client.
 
+pub enum ClientType {
+    // Internal Clients
+    StarknetClient(Arc<JsonRpcClient<HttpTransport>>),
+    DaClient(Arc<Box<dyn DaClient>>),
+    ProverClient(Arc<Box<dyn ProverClient>>),
+    SettlementClient(Arc<Box<dyn SettlementClient>>),
+    Alerts(Arc<Box<dyn Alerts>>),
+
+    // External Clients
+    Database(Arc<Box<dyn Database>>),
+    Queue(Arc<Box<dyn QueueProvider>>),
+    Storage(Arc<Box<dyn DataStorage>>),
+}
+
+// By default, everything is on Dummy.
+pub enum ClientValue {
+    MockBySelf(ClientType),
+    Actual,
+    Dummy,
+}
+
+impl From<JsonRpcClient<HttpTransport>> for ClientValue {
+    fn from(client: JsonRpcClient<HttpTransport>) -> Self {
+        ClientValue::MockBySelf(ClientType::StarknetClient(Arc::new(client)))
+    }
+}
+
+impl From<MockProverClient> for ClientValue {
+    fn from(client: MockProverClient) -> Self {
+        ClientValue::MockBySelf(ClientType::ProverClient(Arc::new(Box::new(client))))
+    }
+}
+
+impl From<MockDatabase> for ClientValue {
+    fn from(client: MockDatabase) -> Self {
+        ClientValue::MockBySelf(ClientType::Database(Arc::new(Box::new(client))))
+    }
+}
+
+impl From<MockDaClient> for ClientValue {
+    fn from(client: MockDaClient) -> Self {
+        ClientValue::MockBySelf(ClientType::DaClient(Arc::new(Box::new(client))))
+    }
+}
+
+impl From<MockQueueProvider> for ClientValue {
+    fn from(client: MockQueueProvider) -> Self {
+        ClientValue::MockBySelf(ClientType::Queue(Arc::new(Box::new(client))))
+    }
+}
+
+impl From<MockDataStorage> for ClientValue {
+    fn from(client: MockDataStorage) -> Self {
+        ClientValue::MockBySelf(ClientType::Storage(Arc::new(Box::new(client))))
+    }
+}
+
+impl From<MockSettlementClient> for ClientValue {
+    fn from(client: MockSettlementClient) -> Self {
+        ClientValue::MockBySelf(ClientType::SettlementClient(Arc::new(Box::new(client))))
+    }
+}
+
+impl From<Box<dyn SettlementClient + Send + Sync>> for ClientValue {
+    fn from(client: Box<dyn SettlementClient + Send + Sync>) -> Self {
+        ClientValue::MockBySelf(ClientType::SettlementClient(Arc::new(client)))
+    }
+}
+
 // TestBuilder for Config
 pub struct TestConfigBuilder {
+    server: MockServer,
+    // Internal Clients
     /// The starknet client to get data from the node
-    starknet_client: Option<Arc<JsonRpcClient<HttpTransport>>>,
-    /// The DA client to interact with the DA layer
-    da_client: Option<Box<dyn DaClient>>,
-    /// The service that produces proof and registers it onchain
-    prover_client: Option<Box<dyn ProverClient>>,
-    /// Settlement client
-    settlement_client: Option<Box<dyn SettlementClient>>,
-    /// The database client
-    database: Option<Box<dyn Database>>,
-    /// Queue client
-    queue: Option<Box<dyn QueueProvider>>,
-    /// Storage client
-    storage: Option<Box<dyn DataStorage>>,
+    starknet_client_option: ClientValue,
     /// Alerts client
-    alerts: Option<Box<dyn Alerts>>,
+    alerts_option: ClientValue,
+    /// The DA client to interact with the DA layer
+    da_client_option: ClientValue,
+    /// The service that produces proof and registers it on chain
+    prover_client_option: ClientValue,
+    /// Settlement client
+    settlement_client_option: ClientValue,
+
+    // External Clients
+    /// The database client
+    database_option: ClientValue,
+    /// Queue client
+    queue_option: ClientValue,
+    /// Storage client
+    storage_option: ClientValue,
 }
 
 impl Default for TestConfigBuilder {
@@ -55,87 +130,205 @@ impl TestConfigBuilder {
     /// Create a new config
     pub fn new() -> TestConfigBuilder {
         TestConfigBuilder {
-            starknet_client: None,
-            da_client: None,
-            prover_client: None,
-            settlement_client: None,
-            database: None,
-            queue: None,
-            storage: None,
-            alerts: None,
+            server: MockServer::start(),
+            starknet_client_option: ClientValue::Dummy,
+            da_client_option: ClientValue::Dummy,
+            prover_client_option: ClientValue::Dummy,
+            settlement_client_option: ClientValue::Dummy,
+            database_option: ClientValue::Dummy,
+            queue_option: ClientValue::Dummy,
+            storage_option: ClientValue::Dummy,
+            alerts_option: ClientValue::Dummy,
         }
     }
 
-    pub fn mock_da_client(mut self, da_client: Box<dyn DaClient>) -> TestConfigBuilder {
-        self.da_client = Some(da_client);
+    pub fn configure_da_client(mut self, da_client_option: ClientValue) -> TestConfigBuilder {
+        self.da_client_option = da_client_option;
         self
     }
 
-    pub fn mock_db_client(mut self, db_client: Box<dyn Database>) -> TestConfigBuilder {
-        self.database = Some(db_client);
+    pub fn configure_settlement_client(mut self, settlement_client_option: ClientValue) -> TestConfigBuilder {
+        self.settlement_client_option = settlement_client_option;
         self
     }
 
-    pub fn mock_settlement_client(mut self, settlement_client: Box<dyn SettlementClient>) -> TestConfigBuilder {
-        self.settlement_client = Some(settlement_client);
+    pub fn configure_starknet_client(mut self, starknet_client_option: ClientValue) -> TestConfigBuilder {
+        self.starknet_client_option = starknet_client_option;
         self
     }
 
-    pub fn mock_starknet_client(mut self, starknet_client: Arc<JsonRpcClient<HttpTransport>>) -> TestConfigBuilder {
-        self.starknet_client = Some(starknet_client);
+    pub fn configure_prover_client(mut self, prover_client_option: ClientValue) -> TestConfigBuilder {
+        self.prover_client_option = prover_client_option;
         self
     }
 
-    pub fn mock_prover_client(mut self, prover_client: Box<dyn ProverClient>) -> TestConfigBuilder {
-        self.prover_client = Some(prover_client);
+    pub fn configure_alerts(mut self, alert_option: ClientValue) -> TestConfigBuilder {
+        self.alerts_option = alert_option;
         self
     }
 
-    pub fn mock_storage_client(mut self, storage_client: Box<dyn DataStorage>) -> TestConfigBuilder {
-        self.storage = Some(storage_client);
+    pub fn configure_storage_client(mut self, storage_client_option: ClientValue) -> TestConfigBuilder {
+        self.starknet_client_option = storage_client_option;
         self
     }
 
-    pub fn mock_queue(mut self, queue: Box<dyn QueueProvider>) -> TestConfigBuilder {
-        self.queue = Some(queue);
+    pub fn configure_queue_client(mut self, queue_option: ClientValue) -> TestConfigBuilder {
+        self.queue_option = queue_option;
+        self
+    }
+    pub fn configure_database(mut self, database_option: ClientValue) -> TestConfigBuilder {
+        self.database_option = database_option;
         self
     }
 
-    pub fn mock_alerts(mut self, alerts: Box<dyn Alerts>) -> TestConfigBuilder {
-        self.alerts = Some(alerts);
-        self
+    async fn init_da_client(&mut self) -> Arc<Box<dyn DaClient>> {
+        match &self.da_client_option {
+            ClientValue::MockBySelf(client) => {
+                if let ClientType::DaClient(da_client) = client {
+                    Arc::clone(da_client)
+                } else {
+                    panic!("MockBySelf client is not a DaClient");
+                }
+            }
+            ClientValue::Actual => Arc::new(build_da_client().await),
+            ClientValue::Dummy => Arc::new(Box::new(MockDaClient::new())),
+        }
+    }
+
+    async fn init_starknet_client(&mut self) -> Arc<JsonRpcClient<HttpTransport>> {
+        let provider = JsonRpcClient::new(HttpTransport::new(
+            Url::parse(format!("http://localhost:{}", self.server.port()).as_str()).expect("Failed to parse URL"),
+        ));
+        match &self.starknet_client_option {
+            ClientValue::MockBySelf(client) => {
+                if let ClientType::StarknetClient(starknet_client) = client {
+                    Arc::clone(starknet_client)
+                } else {
+                    panic!("MockBySelf client is not a StarknetClient");
+                }
+            }
+            ClientValue::Actual => Arc::new(provider),
+            // TODO: There's no mock for this
+            ClientValue::Dummy => Arc::new(provider),
+        }
+    }
+
+    async fn init_prover_client(&mut self) -> Arc<Box<dyn ProverClient>> {
+        let settings_provider = DefaultSettingsProvider {};
+        
+        match &self.prover_client_option {
+            ClientValue::MockBySelf(client) => {
+                if let ClientType::ProverClient(prover_client) = client {
+                    Arc::clone(prover_client)
+                } else {
+                    panic!("MockBySelf client is not a ProverClient");
+                }
+            }
+
+            ClientValue::Actual => {
+                
+                Arc::new(build_prover_service(&settings_provider))
+            }
+            ClientValue::Dummy => {
+                let x: Arc<Box<dyn ProverClient>> = Arc::new(Box::new(MockProverClient::new()));
+                x
+            }
+        }
+    }
+
+    async fn init_settlement_client(&mut self) -> Arc<Box<dyn SettlementClient>> {
+        let settings_provider = DefaultSettingsProvider {};
+        match &self.settlement_client_option {
+            ClientValue::MockBySelf(client) => {
+                if let ClientType::SettlementClient(settlement_client) = client {
+                    Arc::clone(settlement_client)
+                } else {
+                    panic!("MockBySelf client is not a SettlementClient");
+                }
+            }
+            ClientValue::Actual => Arc::new(build_settlement_client(&settings_provider).await),
+            ClientValue::Dummy => Arc::new(Box::new(MockSettlementClient::new())),
+        }
+    }
+
+    async fn init_alerts(&mut self) -> Arc<Box<dyn Alerts>> {
+        match &self.alerts_option {
+            ClientValue::MockBySelf(client) => {
+                if let ClientType::Alerts(alerts) = client {
+                    Arc::clone(alerts)
+                } else {
+                    panic!("MockBySelf client is not an Alerts");
+                }
+            }
+            ClientValue::Actual => Arc::new(build_alert_client().await),
+            ClientValue::Dummy => Arc::new(Box::new(MockAlerts::new())),
+        }
+    }
+
+    async fn init_storage_client(&mut self) -> Arc<Box<dyn DataStorage>> {
+        let aws_config = aws_config::load_from_env().await;
+        match &self.storage_option {
+            ClientValue::MockBySelf(client) => {
+                if let ClientType::Storage(storage) = client {
+                    Arc::clone(storage)
+                } else {
+                    panic!("MockBySelf client is not a Storage");
+                }
+            }
+            ClientValue::Actual => Arc::new(build_storage_client(&aws_config).await),
+            ClientValue::Dummy => Arc::new(Box::new(MockDataStorage::new())),
+        }
+    }
+
+    async fn init_queue_client(&mut self) -> Arc<Box<dyn QueueProvider>> {
+        let aws_config = aws_config::load_from_env().await;
+        match &self.queue_option {
+            ClientValue::MockBySelf(client) => {
+                if let ClientType::Queue(queue) = client {
+                    Arc::clone(queue)
+                } else {
+                    panic!("MockBySelf client is not a Queue");
+                }
+            }
+            ClientValue::Actual => Arc::new(build_queue_client(&aws_config)),
+            ClientValue::Dummy => Arc::new(Box::new(MockQueueProvider::new())),
+        }
+    }
+
+    async fn init_database(&mut self) -> Arc<Box<dyn Database>> {
+        match &self.database_option {
+            ClientValue::MockBySelf(client) => {
+                if let ClientType::Database(database) = client {
+                    Arc::clone(database)
+                } else {
+                    panic!("MockBySelf client is not a Database");
+                }
+            }
+            ClientValue::Actual => Arc::new(build_database_client().await),
+            ClientValue::Dummy => Arc::new(Box::new(MockDatabase::new())),
+        }
     }
 
     pub async fn build(mut self) -> TestConfigBuilderReturns {
         dotenvy::from_filename("../.env.test").expect("Failed to load the .env file");
+        use std::sync::Arc;
 
-        let server = MockServer::start();
-        let settings_provider = DefaultSettingsProvider {};
-
-        // init database
-        if self.database.is_none() {
-            self.database = Some(Box::new(MockDatabase::new()));
+        // Generic function to unwrap Arc<Box<dyn Trait>>
+        fn unwrap_arc<T: ?Sized>(arc: Arc<Box<T>>) -> Box<T> {
+            Arc::try_unwrap(arc).unwrap_or_else(|_| panic!("Unwrapping from Arc panicked."))
         }
 
-        // init the DA client
-        if self.da_client.is_none() {
-            self.da_client = Some(build_da_client().await);
-        }
+        // Usage in your code
+        let starknet_client = self.init_starknet_client().await;
+        let alerts = unwrap_arc(self.init_alerts().await);
+        let da_client = unwrap_arc(self.init_da_client().await);
+        let settlement_client = unwrap_arc(self.init_settlement_client().await);
+        let prover_client = unwrap_arc(self.init_prover_client().await);
 
-        // init the Settings client
-        if self.settlement_client.is_none() {
-            self.settlement_client = Some(build_settlement_client(&settings_provider).await);
-        }
-
-        // init the storage client
-        if self.storage.is_none() {
-            self.storage = Some(Box::new(MockDataStorage::new()));
-        }
-
-        if self.alerts.is_none() {
-            self.alerts = Some(build_alert_client().await);
-        }
-
+        // External Dependencies
+        let storage = unwrap_arc(self.init_storage_client().await);
+        let database = unwrap_arc(self.init_database().await);
+        let queue = unwrap_arc(self.init_queue_client().await);
         // Deleting and Creating the queues in sqs.
         create_sqs_queues().await.expect("Not able to delete and create the queues.");
         // Deleting the database
@@ -144,21 +337,16 @@ impl TestConfigBuilder {
         create_sns_arn().await.expect("Unable to create the sns arn");
 
         let config = Arc::new(Config::new(
-            self.starknet_client.unwrap_or_else(|| {
-                let provider = JsonRpcClient::new(HttpTransport::new(
-                    Url::parse(format!("http://localhost:{}", server.port()).as_str()).expect("Failed to parse URL"),
-                ));
-                Arc::new(provider)
-            }),
-            self.da_client.unwrap(),
-            self.prover_client.unwrap_or_else(|| build_prover_service(&settings_provider)),
-            self.settlement_client.unwrap(),
-            self.database.unwrap(),
-            self.queue.unwrap_or_else(|| Box::new(SqsQueue {})),
-            self.storage.unwrap(),
-            self.alerts.unwrap(),
+            starknet_client,
+            da_client,
+            prover_client,
+            settlement_client,
+            database,
+            queue,
+            storage,
+            alerts,
         ));
 
-        TestConfigBuilderReturns { server, config }
+        TestConfigBuilderReturns { server: self.server, config }
     }
 }

--- a/crates/orchestrator/src/tests/config.rs
+++ b/crates/orchestrator/src/tests/config.rs
@@ -215,7 +215,7 @@ impl TestConfigBuilder {
 
     async fn init_prover_client(&mut self) -> Arc<Box<dyn ProverClient>> {
         let settings_provider = DefaultSettingsProvider {};
-        
+
         match &self.prover_client_option {
             ClientValue::MockBySelf(client) => {
                 if let ClientType::ProverClient(prover_client) = client {
@@ -225,10 +225,7 @@ impl TestConfigBuilder {
                 }
             }
 
-            ClientValue::Actual => {
-                
-                Arc::new(build_prover_service(&settings_provider))
-            }
+            ClientValue::Actual => Arc::new(build_prover_service(&settings_provider)),
             ClientValue::Dummy => {
                 let x: Arc<Box<dyn ProverClient>> = Arc::new(Box::new(MockProverClient::new()));
                 x

--- a/crates/orchestrator/src/tests/config.rs
+++ b/crates/orchestrator/src/tests/config.rs
@@ -76,22 +76,22 @@ impl_mock_from! {
 // TestBuilder for Config
 pub struct TestConfigBuilder {
     /// The starknet client to get data from the node
-    starknet_client_option: ConfigType,
+    starknet_client_type: ConfigType,
     /// The DA client to interact with the DA layer
-    da_client_option: ConfigType,
+    da_client_type: ConfigType,
     /// The service that produces proof and registers it on chain
-    prover_client_option: ConfigType,
+    prover_client_type: ConfigType,
     /// Settlement client
-    settlement_client_option: ConfigType,
+    settlement_client_type: ConfigType,
 
     /// Alerts client
-    alerts_option: ConfigType,
+    alerts_type: ConfigType,
     /// The database client
-    database_option: ConfigType,
+    database_type: ConfigType,
     /// Queue client
-    queue_option: ConfigType,
+    queue_type: ConfigType,
     /// Storage client
-    storage_option: ConfigType,
+    storage_type: ConfigType,
 }
 
 impl Default for TestConfigBuilder {
@@ -109,53 +109,53 @@ impl TestConfigBuilder {
     /// Create a new config
     pub fn new() -> TestConfigBuilder {
         TestConfigBuilder {
-            starknet_client_option: ConfigType::Dummy,
-            da_client_option: ConfigType::Dummy,
-            prover_client_option: ConfigType::Dummy,
-            settlement_client_option: ConfigType::Dummy,
-            database_option: ConfigType::Dummy,
-            queue_option: ConfigType::Dummy,
-            storage_option: ConfigType::Dummy,
-            alerts_option: ConfigType::Dummy,
+            starknet_client_type: ConfigType::Dummy,
+            da_client_type: ConfigType::Dummy,
+            prover_client_type: ConfigType::Dummy,
+            settlement_client_type: ConfigType::Dummy,
+            database_type: ConfigType::Dummy,
+            queue_type: ConfigType::Dummy,
+            storage_type: ConfigType::Dummy,
+            alerts_type: ConfigType::Dummy,
         }
     }
 
-    pub fn configure_da_client(mut self, da_client_option: ConfigType) -> TestConfigBuilder {
-        self.da_client_option = da_client_option;
+    pub fn configure_da_client(mut self, da_client_type: ConfigType) -> TestConfigBuilder {
+        self.da_client_type = da_client_type;
         self
     }
 
-    pub fn configure_settlement_client(mut self, settlement_client_option: ConfigType) -> TestConfigBuilder {
-        self.settlement_client_option = settlement_client_option;
+    pub fn configure_settlement_client(mut self, settlement_client_type: ConfigType) -> TestConfigBuilder {
+        self.settlement_client_type = settlement_client_type;
         self
     }
 
-    pub fn configure_starknet_client(mut self, starknet_client_option: ConfigType) -> TestConfigBuilder {
-        self.starknet_client_option = starknet_client_option;
+    pub fn configure_starknet_client(mut self, starknet_client_type: ConfigType) -> TestConfigBuilder {
+        self.starknet_client_type = starknet_client_type;
         self
     }
 
-    pub fn configure_prover_client(mut self, prover_client_option: ConfigType) -> TestConfigBuilder {
-        self.prover_client_option = prover_client_option;
+    pub fn configure_prover_client(mut self, prover_client_type: ConfigType) -> TestConfigBuilder {
+        self.prover_client_type = prover_client_type;
         self
     }
 
     pub fn configure_alerts(mut self, alert_option: ConfigType) -> TestConfigBuilder {
-        self.alerts_option = alert_option;
+        self.alerts_type = alert_option;
         self
     }
 
     pub fn configure_storage_client(mut self, storage_client_option: ConfigType) -> TestConfigBuilder {
-        self.storage_option = storage_client_option;
+        self.storage_type = storage_client_option;
         self
     }
 
-    pub fn configure_queue_client(mut self, queue_option: ConfigType) -> TestConfigBuilder {
-        self.queue_option = queue_option;
+    pub fn configure_queue_client(mut self, queue_type: ConfigType) -> TestConfigBuilder {
+        self.queue_type = queue_type;
         self
     }
-    pub fn configure_database(mut self, database_option: ConfigType) -> TestConfigBuilder {
-        self.database_option = database_option;
+    pub fn configure_database(mut self, database_type: ConfigType) -> TestConfigBuilder {
+        self.database_type = database_type;
         self
     }
 
@@ -167,28 +167,28 @@ impl TestConfigBuilder {
         use std::sync::Arc;
 
         let TestConfigBuilder {
-            starknet_client_option,
-            alerts_option,
-            da_client_option,
-            prover_client_option,
-            settlement_client_option,
-            database_option,
-            queue_option,
-            storage_option,
+            starknet_client_type,
+            alerts_type,
+            da_client_type,
+            prover_client_type,
+            settlement_client_type,
+            database_type,
+            queue_type,
+            storage_type,
         } = self;
 
-        let (starknet_client, server) = init_starknet_client(starknet_client_option).await;
-        let alerts = init_alerts(alerts_option).await;
-        let da_client = init_da_client(da_client_option).await;
+        let (starknet_client, server) = init_starknet_client(starknet_client_type).await;
+        let alerts = init_alerts(alerts_type, &aws_config).await;
+        let da_client = init_da_client(da_client_type).await;
 
-        let settlement_client = init_settlement_client(settlement_client_option).await;
+        let settlement_client = init_settlement_client(settlement_client_type).await;
 
-        let prover_client = init_prover_client(prover_client_option).await;
+        let prover_client = init_prover_client(prover_client_type).await;
 
         // External Dependencies
-        let storage = init_storage_client(storage_option).await;
-        let database = init_database(database_option).await;
-        let queue = init_queue_client(queue_option).await;
+        let storage = init_storage_client(storage_type).await;
+        let database = init_database(database_type).await;
+        let queue = init_queue_client(queue_type).await;
         // Deleting and Creating the queues in sqs.
         create_sqs_queues().await.expect("Not able to delete and create the queues.");
         // Deleting the database

--- a/crates/orchestrator/src/tests/data_storage/mod.rs
+++ b/crates/orchestrator/src/tests/data_storage/mod.rs
@@ -1,10 +1,8 @@
-use crate::data_storage::aws_s3::config::AWSS3Config;
-use crate::data_storage::aws_s3::AWSS3;
-use crate::data_storage::{DataStorage, DataStorageConfig};
 use bytes::Bytes;
 use rstest::rstest;
 use serde_json::json;
-use utils::env_utils::get_env_var_or_panic;
+
+use crate::tests::config::TestConfigBuilder;
 
 /// This test checks the ability to put and get data from AWS S3 using `AWSS3`.
 /// It puts JSON data into a test bucket and retrieves it, verifying the data
@@ -13,13 +11,11 @@ use utils::env_utils::get_env_var_or_panic;
 #[rstest]
 #[tokio::test]
 async fn test_put_and_get_data_s3() -> color_eyre::Result<()> {
+    let services = TestConfigBuilder::new().build().await;
+
     dotenvy::from_filename("../.env.test")?;
 
-    let config = AWSS3Config::new_from_env();
-    let aws_config =
-        aws_config::load_from_env().await.into_builder().endpoint_url(get_env_var_or_panic("AWS_ENDPOINT_URL")).build();
-    let s3_client = AWSS3::new(config, &aws_config);
-    s3_client.build_test_bucket(&get_env_var_or_panic("AWS_S3_BUCKET_NAME")).await.unwrap();
+    let s3_client = services.config.storage();
 
     let mock_data = json!(
         {

--- a/crates/orchestrator/src/tests/data_storage/mod.rs
+++ b/crates/orchestrator/src/tests/data_storage/mod.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use rstest::rstest;
 use serde_json::json;
 
-use crate::tests::config::TestConfigBuilder;
+use crate::tests::config::{ClientValue, TestConfigBuilder};
 
 /// This test checks the ability to put and get data from AWS S3 using `AWSS3`.
 /// It puts JSON data into a test bucket and retrieves it, verifying the data
@@ -11,7 +11,7 @@ use crate::tests::config::TestConfigBuilder;
 #[rstest]
 #[tokio::test]
 async fn test_put_and_get_data_s3() -> color_eyre::Result<()> {
-    let services = TestConfigBuilder::new().build().await;
+    let services = TestConfigBuilder::new().configure_storage_client(ClientValue::Actual).build().await;
 
     dotenvy::from_filename("../.env.test")?;
 

--- a/crates/orchestrator/src/tests/database/mod.rs
+++ b/crates/orchestrator/src/tests/database/mod.rs
@@ -2,7 +2,7 @@ use rstest::*;
 use uuid::Uuid;
 
 use crate::jobs::types::{ExternalId, JobItem, JobStatus, JobType};
-use crate::tests::config::TestConfigBuilder;
+use crate::tests::config::{ClientValue, TestConfigBuilder};
 
 #[rstest]
 #[tokio::test]
@@ -16,7 +16,7 @@ async fn test_database_connection() -> color_eyre::Result<()> {
 #[rstest]
 #[tokio::test]
 async fn database_create_job_works() {
-    let services = TestConfigBuilder::new().build().await;
+    let services = TestConfigBuilder::new().configure_database(ClientValue::Actual).build().await;
     let config = services.config;
     let database_client = config.database();
 
@@ -55,7 +55,7 @@ async fn database_create_job_works() {
 #[case(false)]
 #[tokio::test]
 async fn database_get_jobs_without_successor_works(#[case] is_successor: bool) {
-    let services = TestConfigBuilder::new().build().await;
+    let services = TestConfigBuilder::new().configure_database(ClientValue::Actual).build().await;
     let config = services.config;
     let database_client = config.database();
 
@@ -99,7 +99,7 @@ async fn database_get_jobs_without_successor_works(#[case] is_successor: bool) {
 #[rstest]
 #[tokio::test]
 async fn database_get_last_successful_job_by_type_works() {
-    let services = TestConfigBuilder::new().build().await;
+    let services = TestConfigBuilder::new().configure_database(ClientValue::Actual).build().await;
     let config = services.config;
     let database_client = config.database();
 
@@ -127,7 +127,7 @@ async fn database_get_last_successful_job_by_type_works() {
 #[rstest]
 #[tokio::test]
 async fn database_get_jobs_after_internal_id_by_job_type_works() {
-    let services = TestConfigBuilder::new().build().await;
+    let services = TestConfigBuilder::new().configure_database(ClientValue::Actual).build().await;
     let config = services.config;
     let database_client = config.database();
 
@@ -162,7 +162,7 @@ async fn database_get_jobs_after_internal_id_by_job_type_works() {
 #[rstest]
 #[tokio::test]
 async fn database_update_job_status_passing_case_works() {
-    let services = TestConfigBuilder::new().build().await;
+    let services = TestConfigBuilder::new().configure_database(ClientValue::Actual).build().await;
     let config = services.config;
 
     let database_client = config.database();
@@ -181,7 +181,7 @@ async fn database_update_job_status_passing_case_works() {
 #[rstest]
 #[tokio::test]
 async fn database_update_job_status_failing_case_works() {
-    let services = TestConfigBuilder::new().build().await;
+    let services = TestConfigBuilder::new().configure_database(ClientValue::Actual).build().await;
     let config = services.config;
     let database_client = config.database();
 

--- a/crates/orchestrator/src/tests/database/mod.rs
+++ b/crates/orchestrator/src/tests/database/mod.rs
@@ -1,30 +1,23 @@
-use crate::config::{config, Config};
+use rstest::*;
+use uuid::Uuid;
+
 use crate::jobs::types::{ExternalId, JobItem, JobStatus, JobType};
 use crate::tests::config::TestConfigBuilder;
-use arc_swap::Guard;
-use rstest::*;
-use std::sync::Arc;
-use uuid::Uuid;
 
 #[rstest]
 #[tokio::test]
 async fn test_database_connection() -> color_eyre::Result<()> {
-    TestConfigBuilder::new().build().await;
+    let _services = TestConfigBuilder::new().build().await;
     Ok(())
-}
-
-#[fixture]
-async fn get_config() -> Guard<Arc<Config>> {
-    config().await
 }
 
 /// Tests for `create_job` operation in database trait.
 /// Creates 3 jobs and asserts them.
 #[rstest]
 #[tokio::test]
-async fn database_create_job_works(#[future] get_config: Guard<Arc<Config>>) {
-    TestConfigBuilder::new().build().await;
-    let config = get_config.await;
+async fn database_create_job_works() {
+    let services = TestConfigBuilder::new().build().await;
+    let config = services.config;
     let database_client = config.database();
 
     let job_vec = [
@@ -61,12 +54,9 @@ async fn database_create_job_works(#[future] get_config: Guard<Arc<Config>>) {
 #[case(true)]
 #[case(false)]
 #[tokio::test]
-async fn database_get_jobs_without_successor_works(
-    #[future] get_config: Guard<Arc<Config>>,
-    #[case] is_successor: bool,
-) {
-    TestConfigBuilder::new().build().await;
-    let config = get_config.await;
+async fn database_get_jobs_without_successor_works(#[case] is_successor: bool) {
+    let services = TestConfigBuilder::new().build().await;
+    let config = services.config;
     let database_client = config.database();
 
     let job_vec = [
@@ -108,9 +98,9 @@ async fn database_get_jobs_without_successor_works(
 /// - Should return the last successful job
 #[rstest]
 #[tokio::test]
-async fn database_get_last_successful_job_by_type_works(#[future] get_config: Guard<Arc<Config>>) {
-    TestConfigBuilder::new().build().await;
-    let config = get_config.await;
+async fn database_get_last_successful_job_by_type_works() {
+    let services = TestConfigBuilder::new().build().await;
+    let config = services.config;
     let database_client = config.database();
 
     let job_vec = [
@@ -136,9 +126,9 @@ async fn database_get_last_successful_job_by_type_works(#[future] get_config: Gu
 /// - Should return the jobs after internal id
 #[rstest]
 #[tokio::test]
-async fn database_get_jobs_after_internal_id_by_job_type_works(#[future] get_config: Guard<Arc<Config>>) {
-    TestConfigBuilder::new().build().await;
-    let config = get_config.await;
+async fn database_get_jobs_after_internal_id_by_job_type_works() {
+    let services = TestConfigBuilder::new().build().await;
+    let config = services.config;
     let database_client = config.database();
 
     let job_vec = [
@@ -171,9 +161,10 @@ async fn database_get_jobs_after_internal_id_by_job_type_works(#[future] get_con
 /// Happy Case : Creating a job with version 0 and updating the job with version 0 update only.
 #[rstest]
 #[tokio::test]
-async fn database_update_job_status_passing_case_works(#[future] get_config: Guard<Arc<Config>>) {
-    TestConfigBuilder::new().build().await;
-    let config = get_config.await;
+async fn database_update_job_status_passing_case_works() {
+    let services = TestConfigBuilder::new().build().await;
+    let config = services.config;
+
     let database_client = config.database();
 
     let job = build_job_item(JobType::SnosRun, JobStatus::Created, 1);
@@ -189,9 +180,9 @@ async fn database_update_job_status_passing_case_works(#[future] get_config: Gua
 /// Failing Case : Creating a job with version 1 and updating the job with version 0 update only.
 #[rstest]
 #[tokio::test]
-async fn database_update_job_status_failing_case_works(#[future] get_config: Guard<Arc<Config>>) {
-    TestConfigBuilder::new().build().await;
-    let config = get_config.await;
+async fn database_update_job_status_failing_case_works() {
+    let services = TestConfigBuilder::new().build().await;
+    let config = services.config;
     let database_client = config.database();
 
     // Scenario :

--- a/crates/orchestrator/src/tests/jobs/da_job/mod.rs
+++ b/crates/orchestrator/src/tests/jobs/da_job/mod.rs
@@ -1,19 +1,22 @@
-use crate::jobs::da_job::test::{get_nonce_attached, read_state_update_from_file};
-use crate::jobs::da_job::{DaError, DaJob};
-use crate::jobs::types::{ExternalId, JobItem, JobStatus, JobType};
-use crate::jobs::JobError;
-use crate::tests::common::drop_database;
-use crate::tests::config::TestConfigBuilder;
-use crate::{config::config, jobs::Job};
+use std::collections::HashMap;
+
 use assert_matches::assert_matches;
 use color_eyre::eyre::eyre;
-use da_client_interface::MockDaClient;
 use mockall::predicate::always;
 use rstest::rstest;
 use serde_json::json;
 use starknet_core::types::{FieldElement, MaybePendingStateUpdate, PendingStateUpdate, StateDiff};
-use std::collections::HashMap;
 use uuid::Uuid;
+
+use da_client_interface::MockDaClient;
+
+use crate::jobs::da_job::test::{get_nonce_attached, read_state_update_from_file};
+use crate::jobs::da_job::{DaError, DaJob};
+use crate::jobs::types::{ExternalId, JobItem, JobStatus, JobType};
+use crate::jobs::Job;
+use crate::jobs::JobError;
+use crate::tests::common::drop_database;
+use crate::tests::config::TestConfigBuilder;
 
 /// Tests the DA Job's handling of a blob length exceeding the supported size.
 /// It mocks the DA client to simulate the environment and expects an error on job processing.
@@ -39,27 +42,25 @@ async fn test_da_job_process_job_failure_on_small_blob_size(
     da_client.expect_max_blob_per_txn().with().returning(|| 1);
     da_client.expect_max_bytes_per_blob().with().returning(|| 1200);
 
-    let server = TestConfigBuilder::new().mock_da_client(Box::new(da_client)).build().await;
-    let config = config().await;
+    let services = TestConfigBuilder::new().mock_da_client(Box::new(da_client)).build().await;
 
     let state_update = read_state_update_from_file(state_update_file.as_str()).expect("issue while reading");
 
     let state_update = MaybePendingStateUpdate::Update(state_update);
     let state_update = serde_json::to_value(&state_update).unwrap();
     let response = json!({ "id": 640641,"jsonrpc":"2.0","result": state_update });
+    get_nonce_attached(&services.server, nonces_file.as_str());
 
-    get_nonce_attached(&server, nonces_file.as_str());
-
-    let state_update_mock = server.mock(|when, then| {
+    let state_update_mock = services.server.mock(|when, then| {
         when.path("/").body_contains("starknet_getStateUpdate");
         then.status(200).body(serde_json::to_vec(&response).unwrap());
     });
 
-    let max_blob_per_txn = config.da_client().max_blob_per_txn().await;
+    let max_blob_per_txn = services.config.da_client().max_blob_per_txn().await;
 
     let response = DaJob
         .process_job(
-            config.as_ref(),
+            services.config,
             &mut JobItem {
                 id: Uuid::default(),
                 internal_id: internal_id.to_string(),
@@ -91,8 +92,8 @@ async fn test_da_job_process_job_failure_on_small_blob_size(
 #[rstest]
 #[tokio::test]
 async fn test_da_job_process_job_failure_on_pending_block() {
-    let server = TestConfigBuilder::new().build().await;
-    let config = config().await;
+    let services = TestConfigBuilder::new().build().await;
+    let server = services.server;
     let internal_id = "1";
 
     let pending_state_update = MaybePendingStateUpdate::PendingUpdate(PendingStateUpdate {
@@ -117,7 +118,7 @@ async fn test_da_job_process_job_failure_on_pending_block() {
 
     let response = DaJob
         .process_job(
-            config.as_ref(),
+            services.config,
             &mut JobItem {
                 id: Uuid::default(),
                 internal_id: internal_id.to_string(),
@@ -176,8 +177,8 @@ async fn test_da_job_process_job_success(
     da_client.expect_max_blob_per_txn().with().returning(|| 6);
     da_client.expect_max_bytes_per_blob().with().returning(|| 131072);
 
-    let server = TestConfigBuilder::new().mock_da_client(Box::new(da_client)).build().await;
-    let config = config().await;
+    let services = TestConfigBuilder::new().mock_da_client(Box::new(da_client)).build().await;
+    let server = services.server;
 
     let state_update = read_state_update_from_file(state_update_file.as_str()).expect("issue while reading");
 
@@ -193,7 +194,7 @@ async fn test_da_job_process_job_success(
 
     let response = DaJob
         .process_job(
-            config.as_ref(),
+            services.config,
             &mut JobItem {
                 id: Uuid::default(),
                 internal_id: internal_id.to_string(),

--- a/crates/orchestrator/src/tests/jobs/da_job/mod.rs
+++ b/crates/orchestrator/src/tests/jobs/da_job/mod.rs
@@ -42,7 +42,7 @@ async fn test_da_job_process_job_failure_on_small_blob_size(
     da_client.expect_max_blob_per_txn().with().returning(|| 1);
     da_client.expect_max_bytes_per_blob().with().returning(|| 1200);
 
-    let services = TestConfigBuilder::new().mock_da_client(Box::new(da_client)).build().await;
+    let services = TestConfigBuilder::new().configure_da_client(da_client.into()).build().await;
 
     let state_update = read_state_update_from_file(state_update_file.as_str()).expect("issue while reading");
 
@@ -177,7 +177,7 @@ async fn test_da_job_process_job_success(
     da_client.expect_max_blob_per_txn().with().returning(|| 6);
     da_client.expect_max_bytes_per_blob().with().returning(|| 131072);
 
-    let services = TestConfigBuilder::new().mock_da_client(Box::new(da_client)).build().await;
+    let services = TestConfigBuilder::new().configure_da_client(da_client.into()).build().await;
     let server = services.server;
 
     let state_update = read_state_update_from_file(state_update_file.as_str()).expect("issue while reading");

--- a/crates/orchestrator/src/tests/jobs/mod.rs
+++ b/crates/orchestrator/src/tests/jobs/mod.rs
@@ -1,8 +1,23 @@
-use rstest::rstest;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
 
-use crate::config::config;
+use assert_matches::assert_matches;
+use mockall::predicate::eq;
+use mongodb::bson::doc;
+use omniqueue::QueueError;
+use rstest::rstest;
+use tokio::time::sleep;
+use uuid::Uuid;
+
+use crate::jobs::constants::{JOB_PROCESS_ATTEMPT_METADATA_KEY, JOB_VERIFICATION_ATTEMPT_METADATA_KEY};
 use crate::jobs::handle_job_failure;
+use crate::jobs::job_handler_factory::mock_factory;
 use crate::jobs::types::JobType;
+use crate::jobs::types::{ExternalId, JobItem, JobVerificationStatus};
+use crate::jobs::{create_job, increment_key_in_metadata, process_job, verify_job, Job, MockJob};
+use crate::queue::job_queue::{JOB_PROCESSING_QUEUE, JOB_VERIFICATION_QUEUE};
+use crate::tests::common::MessagePayloadType;
 use crate::{jobs::types::JobStatus, tests::config::TestConfigBuilder};
 
 use super::database::build_job_item;
@@ -16,24 +31,6 @@ pub mod proving_job;
 #[cfg(test)]
 pub mod state_update_job;
 
-use assert_matches::assert_matches;
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::Duration;
-
-use mockall::predicate::eq;
-use mongodb::bson::doc;
-use omniqueue::QueueError;
-use tokio::time::sleep;
-use uuid::Uuid;
-
-use crate::jobs::constants::{JOB_PROCESS_ATTEMPT_METADATA_KEY, JOB_VERIFICATION_ATTEMPT_METADATA_KEY};
-use crate::jobs::job_handler_factory::mock_factory;
-use crate::jobs::types::{ExternalId, JobItem, JobVerificationStatus};
-use crate::jobs::{create_job, increment_key_in_metadata, process_job, verify_job, Job, MockJob};
-use crate::queue::job_queue::{JOB_PROCESSING_QUEUE, JOB_VERIFICATION_QUEUE};
-use crate::tests::common::MessagePayloadType;
-
 /// Tests `create_job` function when job is not existing in the db.
 #[rstest]
 #[tokio::test]
@@ -45,22 +42,21 @@ async fn create_job_job_does_not_exists_in_db_works() {
     let job_item_clone = job_item.clone();
     job_handler.expect_create_job().times(1).returning(move |_, _, _| Ok(job_item_clone.clone()));
 
-    TestConfigBuilder::new().build().await;
-    let config = config().await;
+    let services = TestConfigBuilder::new().build().await;
 
     // Mocking the `get_job_handler` call in create_job function.
     let job_handler: Arc<Box<dyn Job>> = Arc::new(Box::new(job_handler));
     let ctx = mock_factory::get_job_handler_context();
     ctx.expect().times(1).with(eq(JobType::SnosRun)).return_once(move |_| Arc::clone(&job_handler));
 
-    assert!(create_job(JobType::SnosRun, "0".to_string(), HashMap::new()).await.is_ok());
+    assert!(create_job(JobType::SnosRun, "0".to_string(), HashMap::new(), services.config.clone()).await.is_ok());
 
     let mut hashmap: HashMap<String, String> = HashMap::new();
     hashmap.insert(JOB_PROCESS_ATTEMPT_METADATA_KEY.to_string(), "0".to_string());
     hashmap.insert(JOB_VERIFICATION_ATTEMPT_METADATA_KEY.to_string(), "0".to_string());
 
     // Db checks.
-    let job_in_db = config.database().get_job_by_id(job_item.id).await.unwrap().unwrap();
+    let job_in_db = services.config.database().get_job_by_id(job_item.id).await.unwrap().unwrap();
     assert_eq!(job_in_db.id, job_item.id);
     assert_eq!(job_in_db.internal_id, job_item.internal_id);
     assert_eq!(job_in_db.metadata, hashmap);
@@ -69,7 +65,8 @@ async fn create_job_job_does_not_exists_in_db_works() {
     sleep(Duration::from_secs(5)).await;
 
     // Queue checks.
-    let consumed_messages = config.queue().consume_message_from_queue(JOB_PROCESSING_QUEUE.to_string()).await.unwrap();
+    let consumed_messages =
+        services.config.queue().consume_message_from_queue(JOB_PROCESSING_QUEUE.to_string()).await.unwrap();
     let consumed_message_payload: MessagePayloadType = consumed_messages.payload_serde_json().unwrap().unwrap();
     assert_eq!(consumed_message_payload.id, job_item.id);
 }
@@ -80,20 +77,21 @@ async fn create_job_job_does_not_exists_in_db_works() {
 async fn create_job_job_exists_in_db_works() {
     let job_item = build_job_item_by_type_and_status(JobType::ProofCreation, JobStatus::Created, "0".to_string());
 
-    TestConfigBuilder::new().build().await;
+    let services = TestConfigBuilder::new().build().await;
 
-    let config = config().await;
-    let database_client = config.database();
+    let database_client = services.config.database();
     database_client.create_job(job_item).await.unwrap();
 
-    assert!(create_job(JobType::ProofCreation, "0".to_string(), HashMap::new()).await.is_err());
+    assert!(create_job(JobType::ProofCreation, "0".to_string(), HashMap::new(), services.config.clone())
+        .await
+        .is_err());
 
     // Waiting for 5 secs for message to be passed into the queue
     sleep(Duration::from_secs(5)).await;
 
     // Queue checks.
     let consumed_messages =
-        config.queue().consume_message_from_queue(JOB_PROCESSING_QUEUE.to_string()).await.unwrap_err();
+        services.config.queue().consume_message_from_queue(JOB_PROCESSING_QUEUE.to_string()).await.unwrap_err();
     assert_matches!(consumed_messages, QueueError::NoData);
 }
 
@@ -103,21 +101,22 @@ async fn create_job_job_exists_in_db_works() {
 #[should_panic(expected = "Job type not implemented yet.")]
 #[tokio::test]
 async fn create_job_job_handler_is_not_implemented_panics() {
-    TestConfigBuilder::new().build().await;
-    let config = config().await;
+    let services = TestConfigBuilder::new().build().await;
 
     // Mocking the `get_job_handler` call in create_job function.
     let ctx = mock_factory::get_job_handler_context();
     ctx.expect().times(1).returning(|_| panic!("Job type not implemented yet."));
 
-    assert!(create_job(JobType::ProofCreation, "0".to_string(), HashMap::new()).await.is_err());
+    assert!(create_job(JobType::ProofCreation, "0".to_string(), HashMap::new(), services.config.clone())
+        .await
+        .is_err());
 
     // Waiting for 5 secs for message to be passed into the queue
     sleep(Duration::from_secs(5)).await;
 
     // Queue checks.
     let consumed_messages =
-        config.queue().consume_message_from_queue(JOB_PROCESSING_QUEUE.to_string()).await.unwrap_err();
+        services.config.queue().consume_message_from_queue(JOB_PROCESSING_QUEUE.to_string()).await.unwrap_err();
     assert_matches!(consumed_messages, QueueError::NoData);
 }
 
@@ -134,9 +133,8 @@ async fn process_job_with_job_exists_in_db_and_valid_job_processing_status_works
     let job_item = build_job_item_by_type_and_status(job_type.clone(), job_status.clone(), "1".to_string());
 
     // Building config
-    TestConfigBuilder::new().build().await;
-    let config = config().await;
-    let database_client = config.database();
+    let services = TestConfigBuilder::new().build().await;
+    let database_client = services.config.database();
 
     let mut job_handler = MockJob::new();
 
@@ -151,7 +149,7 @@ async fn process_job_with_job_exists_in_db_and_valid_job_processing_status_works
     let ctx = mock_factory::get_job_handler_context();
     ctx.expect().times(1).with(eq(job_type.clone())).returning(move |_| Arc::clone(&job_handler));
 
-    assert!(process_job(job_item.id).await.is_ok());
+    assert!(process_job(job_item.id, services.config.clone()).await.is_ok());
     // Getting the updated job.
     let updated_job = database_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
     // checking if job_status is updated in db
@@ -164,7 +162,7 @@ async fn process_job_with_job_exists_in_db_and_valid_job_processing_status_works
 
     // Queue checks
     let consumed_messages =
-        config.queue().consume_message_from_queue(JOB_VERIFICATION_QUEUE.to_string()).await.unwrap();
+        services.config.queue().consume_message_from_queue(JOB_VERIFICATION_QUEUE.to_string()).await.unwrap();
     let consumed_message_payload: MessagePayloadType = consumed_messages.payload_serde_json().unwrap().unwrap();
     assert_eq!(consumed_message_payload.id, job_item.id);
 }
@@ -178,14 +176,13 @@ async fn process_job_with_job_exists_in_db_with_invalid_job_processing_status_er
     let job_item = build_job_item_by_type_and_status(JobType::SnosRun, JobStatus::Completed, "1".to_string());
 
     // building config
-    TestConfigBuilder::new().build().await;
-    let config = config().await;
-    let database_client = config.database();
+    let services = TestConfigBuilder::new().build().await;
+    let database_client = services.config.database();
 
     // creating job in database
     database_client.create_job(job_item.clone()).await.unwrap();
 
-    assert!(process_job(job_item.id).await.is_err());
+    assert!(process_job(job_item.id, services.config.clone()).await.is_err());
 
     let job_in_db = database_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
     // Job should be untouched in db.
@@ -196,7 +193,7 @@ async fn process_job_with_job_exists_in_db_with_invalid_job_processing_status_er
 
     // Queue checks.
     let consumed_messages =
-        config.queue().consume_message_from_queue(JOB_VERIFICATION_QUEUE.to_string()).await.unwrap_err();
+        services.config.queue().consume_message_from_queue(JOB_VERIFICATION_QUEUE.to_string()).await.unwrap_err();
     assert_matches!(consumed_messages, QueueError::NoData);
 }
 
@@ -209,17 +206,16 @@ async fn process_job_job_does_not_exists_in_db_works() {
     let job_item = build_job_item_by_type_and_status(JobType::SnosRun, JobStatus::Created, "1".to_string());
 
     // building config
-    TestConfigBuilder::new().build().await;
-    let config = config().await;
+    let services = TestConfigBuilder::new().build().await;
 
-    assert!(process_job(job_item.id).await.is_err());
+    assert!(process_job(job_item.id, services.config.clone()).await.is_err());
 
     // Waiting for 5 secs for message to be passed into the queue
     sleep(Duration::from_secs(5)).await;
 
     // Queue checks.
     let consumed_messages =
-        config.queue().consume_message_from_queue(JOB_VERIFICATION_QUEUE.to_string()).await.unwrap_err();
+        services.config.queue().consume_message_from_queue(JOB_VERIFICATION_QUEUE.to_string()).await.unwrap_err();
     assert_matches!(consumed_messages, QueueError::NoData);
 }
 
@@ -241,18 +237,20 @@ async fn process_job_two_workers_process_same_job_works() {
     ctx.expect().times(1).with(eq(JobType::SnosRun)).returning(move |_| Arc::clone(&job_handler));
 
     // building config
-    TestConfigBuilder::new().build().await;
-    let config = config().await;
-    let db_client = config.database();
+    let services = TestConfigBuilder::new().build().await;
+    let db_client = services.config.database();
 
     let job_item = build_job_item_by_type_and_status(JobType::SnosRun, JobStatus::Created, "1".to_string());
 
     // Creating the job in the db
     db_client.create_job(job_item.clone()).await.unwrap();
 
-    // Simulating the two workers
-    let worker_1 = tokio::spawn(async move { process_job(job_item.id).await });
-    let worker_2 = tokio::spawn(async move { process_job(job_item.id).await });
+    let config_1 = services.config.clone();
+    let config_2 = services.config.clone();
+
+    // Simulating the two workers, Uuid has in-built copy trait
+    let worker_1 = tokio::spawn(async move { process_job(job_item.id, config_1).await });
+    let worker_2 = tokio::spawn(async move { process_job(job_item.id, config_2).await });
 
     // waiting for workers to complete the processing
     let (result_1, result_2) = tokio::join!(worker_1, worker_2);
@@ -279,10 +277,9 @@ async fn verify_job_with_verified_status_works() {
         build_job_item_by_type_and_status(JobType::DataSubmission, JobStatus::PendingVerification, "1".to_string());
 
     // building config
-    TestConfigBuilder::new().build().await;
+    let services = TestConfigBuilder::new().build().await;
 
-    let config = config().await;
-    let database_client = config.database();
+    let database_client = services.config.database();
     let mut job_handler = MockJob::new();
 
     // creating job in database
@@ -296,7 +293,7 @@ async fn verify_job_with_verified_status_works() {
     // Mocking the `get_job_handler` call in create_job function.
     ctx.expect().times(1).with(eq(JobType::DataSubmission)).returning(move |_| Arc::clone(&job_handler));
 
-    assert!(verify_job(job_item.id).await.is_ok());
+    assert!(verify_job(job_item.id, services.config.clone()).await.is_ok());
 
     // DB checks.
     let updated_job = database_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
@@ -307,10 +304,10 @@ async fn verify_job_with_verified_status_works() {
 
     // Queue checks.
     let consumed_messages_verification_queue =
-        config.queue().consume_message_from_queue(JOB_VERIFICATION_QUEUE.to_string()).await.unwrap_err();
+        services.config.queue().consume_message_from_queue(JOB_VERIFICATION_QUEUE.to_string()).await.unwrap_err();
     assert_matches!(consumed_messages_verification_queue, QueueError::NoData);
     let consumed_messages_processing_queue =
-        config.queue().consume_message_from_queue(JOB_PROCESSING_QUEUE.to_string()).await.unwrap_err();
+        services.config.queue().consume_message_from_queue(JOB_PROCESSING_QUEUE.to_string()).await.unwrap_err();
     assert_matches!(consumed_messages_processing_queue, QueueError::NoData);
 }
 
@@ -323,10 +320,9 @@ async fn verify_job_with_rejected_status_adds_to_queue_works() {
         build_job_item_by_type_and_status(JobType::DataSubmission, JobStatus::PendingVerification, "1".to_string());
 
     // building config
-    TestConfigBuilder::new().build().await;
+    let services = TestConfigBuilder::new().build().await;
 
-    let config = config().await;
-    let database_client = config.database();
+    let database_client = services.config.database();
     let mut job_handler = MockJob::new();
 
     // creating job in database
@@ -339,7 +335,7 @@ async fn verify_job_with_rejected_status_adds_to_queue_works() {
     // Mocking the `get_job_handler` call in create_job function.
     ctx.expect().times(1).with(eq(JobType::DataSubmission)).returning(move |_| Arc::clone(&job_handler));
 
-    assert!(verify_job(job_item.id).await.is_ok());
+    assert!(verify_job(job_item.id, services.config.clone()).await.is_ok());
 
     // DB checks.
     let updated_job = database_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
@@ -349,7 +345,8 @@ async fn verify_job_with_rejected_status_adds_to_queue_works() {
     sleep(Duration::from_secs(5)).await;
 
     // Queue checks.
-    let consumed_messages = config.queue().consume_message_from_queue(JOB_PROCESSING_QUEUE.to_string()).await.unwrap();
+    let consumed_messages =
+        services.config.queue().consume_message_from_queue(JOB_PROCESSING_QUEUE.to_string()).await.unwrap();
     let consumed_message_payload: MessagePayloadType = consumed_messages.payload_serde_json().unwrap().unwrap();
     assert_eq!(consumed_message_payload.id, job_item.id);
 }
@@ -368,10 +365,9 @@ async fn verify_job_with_rejected_status_works() {
     job_item.metadata = metadata;
 
     // building config
-    TestConfigBuilder::new().build().await;
+    let services = TestConfigBuilder::new().build().await;
 
-    let config = config().await;
-    let database_client = config.database();
+    let database_client = services.config.database();
     let mut job_handler = MockJob::new();
 
     // creating job in database
@@ -385,7 +381,7 @@ async fn verify_job_with_rejected_status_works() {
     // Mocking the `get_job_handler` call in create_job function.
     ctx.expect().times(1).with(eq(JobType::DataSubmission)).returning(move |_| Arc::clone(&job_handler));
 
-    assert!(verify_job(job_item.id).await.is_ok());
+    assert!(verify_job(job_item.id, services.config.clone()).await.is_ok());
 
     // DB checks.
     let updated_job = database_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
@@ -397,7 +393,7 @@ async fn verify_job_with_rejected_status_works() {
 
     // Queue checks.
     let consumed_messages_processing_queue =
-        config.queue().consume_message_from_queue(JOB_PROCESSING_QUEUE.to_string()).await.unwrap_err();
+        services.config.queue().consume_message_from_queue(JOB_PROCESSING_QUEUE.to_string()).await.unwrap_err();
     assert_matches!(consumed_messages_processing_queue, QueueError::NoData);
 }
 
@@ -410,10 +406,9 @@ async fn verify_job_with_pending_status_adds_to_queue_works() {
         build_job_item_by_type_and_status(JobType::DataSubmission, JobStatus::PendingVerification, "1".to_string());
 
     // building config
-    TestConfigBuilder::new().build().await;
+    let services = TestConfigBuilder::new().build().await;
 
-    let config = config().await;
-    let database_client = config.database();
+    let database_client = services.config.database();
     let mut job_handler = MockJob::new();
 
     // creating job in database
@@ -428,7 +423,7 @@ async fn verify_job_with_pending_status_adds_to_queue_works() {
     // Mocking the `get_job_handler` call in create_job function.
     ctx.expect().times(1).with(eq(JobType::DataSubmission)).returning(move |_| Arc::clone(&job_handler));
 
-    assert!(verify_job(job_item.id).await.is_ok());
+    assert!(verify_job(job_item.id, services.config.clone()).await.is_ok());
 
     // DB checks.
     let updated_job = database_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
@@ -440,7 +435,7 @@ async fn verify_job_with_pending_status_adds_to_queue_works() {
 
     // Queue checks
     let consumed_messages =
-        config.queue().consume_message_from_queue(JOB_VERIFICATION_QUEUE.to_string()).await.unwrap();
+        services.config.queue().consume_message_from_queue(JOB_VERIFICATION_QUEUE.to_string()).await.unwrap();
     let consumed_message_payload: MessagePayloadType = consumed_messages.payload_serde_json().unwrap().unwrap();
     assert_eq!(consumed_message_payload.id, job_item.id);
 }
@@ -459,10 +454,9 @@ async fn verify_job_with_pending_status_works() {
     job_item.metadata = metadata;
 
     // building config
-    TestConfigBuilder::new().build().await;
+    let services = TestConfigBuilder::new().build().await;
 
-    let config = config().await;
-    let database_client = config.database();
+    let database_client = services.config.database();
     let mut job_handler = MockJob::new();
 
     // creating job in database
@@ -477,7 +471,7 @@ async fn verify_job_with_pending_status_works() {
     // Mocking the `get_job_handler` call in create_job function.
     ctx.expect().times(1).with(eq(JobType::DataSubmission)).returning(move |_| Arc::clone(&job_handler));
 
-    assert!(verify_job(job_item.id).await.is_ok());
+    assert!(verify_job(job_item.id, services.config.clone()).await.is_ok());
 
     // DB checks.
     let updated_job = database_client.get_job_by_id(job_item.id).await.unwrap().unwrap();
@@ -489,7 +483,7 @@ async fn verify_job_with_pending_status_works() {
 
     // Queue checks.
     let consumed_messages_verification_queue =
-        config.queue().consume_message_from_queue(JOB_VERIFICATION_QUEUE.to_string()).await.unwrap_err();
+        services.config.queue().consume_message_from_queue(JOB_VERIFICATION_QUEUE.to_string()).await.unwrap_err();
     assert_matches!(consumed_messages_verification_queue, QueueError::NoData);
 }
 
@@ -518,9 +512,9 @@ fn build_job_item_by_type_and_status(job_type: JobType, job_status: JobStatus, i
 #[case(JobType::DataSubmission, JobStatus::VerificationFailed)]
 #[tokio::test]
 async fn handle_job_failure_with_failed_job_status_works(#[case] job_type: JobType, #[case] job_status: JobStatus) {
-    TestConfigBuilder::new().build().await;
-    let config = config().await;
-    let database_client = config.database();
+    let services = TestConfigBuilder::new().build().await;
+
+    let database_client = services.config.database();
     let internal_id = 1;
 
     // create a job, with already available "last_job_status"
@@ -535,9 +529,10 @@ async fn handle_job_failure_with_failed_job_status_works(#[case] job_type: JobTy
     database_client.create_job(job_expected.clone()).await.unwrap();
 
     // calling handle_job_failure
-    handle_job_failure(job_id).await.expect("handle_job_failure failed to run");
+    handle_job_failure(job_id, services.config.clone()).await.expect("handle_job_failure failed to run");
 
-    let job_fetched = config.database().get_job_by_id(job_id).await.expect("Unable to fetch Job Data").unwrap();
+    let job_fetched =
+        services.config.database().get_job_by_id(job_id).await.expect("Unable to fetch Job Data").unwrap();
 
     assert_eq!(job_fetched, job_expected);
 }
@@ -547,9 +542,9 @@ async fn handle_job_failure_with_failed_job_status_works(#[case] job_type: JobTy
 #[case::verification_timeout(JobType::SnosRun, JobStatus::VerificationTimeout)]
 #[tokio::test]
 async fn handle_job_failure_with_correct_job_status_works(#[case] job_type: JobType, #[case] job_status: JobStatus) {
-    TestConfigBuilder::new().build().await;
-    let config = config().await;
-    let database_client = config.database();
+    let services = TestConfigBuilder::new().build().await;
+
+    let database_client = services.config.database();
     let internal_id = 1;
 
     // create a job
@@ -560,9 +555,10 @@ async fn handle_job_failure_with_correct_job_status_works(#[case] job_type: JobT
     database_client.create_job(job.clone()).await.unwrap();
 
     // calling handle_job_failure
-    handle_job_failure(job_id).await.expect("handle_job_failure failed to run");
+    handle_job_failure(job_id, services.config.clone()).await.expect("handle_job_failure failed to run");
 
-    let job_fetched = config.database().get_job_by_id(job_id).await.expect("Unable to fetch Job Data").unwrap();
+    let job_fetched =
+        services.config.database().get_job_by_id(job_id).await.expect("Unable to fetch Job Data").unwrap();
 
     // creating expected output
     let mut job_expected = job.clone();
@@ -581,9 +577,9 @@ async fn handle_job_failure_with_correct_job_status_works(#[case] job_type: JobT
 async fn handle_job_failure_job_status_completed_works(#[case] job_type: JobType) {
     let job_status = JobStatus::Completed;
 
-    TestConfigBuilder::new().build().await;
-    let config = config().await;
-    let database_client = config.database();
+    let services = TestConfigBuilder::new().build().await;
+
+    let database_client = services.config.database();
     let internal_id = 1;
 
     // create a job
@@ -594,10 +590,13 @@ async fn handle_job_failure_job_status_completed_works(#[case] job_type: JobType
     database_client.create_job(job_expected.clone()).await.unwrap();
 
     // calling handle_job_failure
-    handle_job_failure(job_id).await.expect("Test call to handle_job_failure should have passed.");
+    handle_job_failure(job_id, services.config.clone())
+        .await
+        .expect("Test call to handle_job_failure should have passed.");
 
     // The completed job status on db is untouched.
-    let job_fetched = config.database().get_job_by_id(job_id).await.expect("Unable to fetch Job Data").unwrap();
+    let job_fetched =
+        services.config.database().get_job_by_id(job_id).await.expect("Unable to fetch Job Data").unwrap();
 
     assert_eq!(job_fetched, job_expected);
 }

--- a/crates/orchestrator/src/tests/jobs/proving_job/mod.rs
+++ b/crates/orchestrator/src/tests/jobs/proving_job/mod.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
-use std::sync::Arc;
 
 use crate::data_storage::MockDataStorage;
 use httpmock::prelude::*;
@@ -45,7 +44,7 @@ async fn test_verify_job(#[from(default_job_item)] mut job_item: JobItem) {
     let mut prover_client = MockProverClient::new();
     prover_client.expect_get_task_status().times(1).returning(|_| Ok(TaskStatus::Succeeded));
 
-    let services = TestConfigBuilder::new().mock_prover_client(Box::new(prover_client)).build().await;
+    let services = TestConfigBuilder::new().configure_prover_client(prover_client.into()).build().await;
 
     assert!(ProvingJob.verify_job(services.config, &mut job_item).await.is_ok());
 }
@@ -71,9 +70,9 @@ async fn test_process_job() {
     storage.expect_get_data().with(eq("0/pie.zip")).return_once(move |_| Ok(buffer_bytes));
 
     let services = TestConfigBuilder::new()
-        .mock_starknet_client(Arc::new(provider))
-        .mock_prover_client(Box::new(prover_client))
-        .mock_storage_client(Box::new(storage))
+        .configure_starknet_client(provider.into())
+        .configure_prover_client(prover_client.into())
+        .configure_storage_client(storage.into())
         .build()
         .await;
 

--- a/crates/orchestrator/src/tests/jobs/state_update_job/mod.rs
+++ b/crates/orchestrator/src/tests/jobs/state_update_job/mod.rs
@@ -5,15 +5,17 @@ use std::sync::Arc;
 
 use assert_matches::assert_matches;
 use bytes::Bytes;
+use color_eyre::eyre::eyre;
 use httpmock::prelude::*;
+use lazy_static::lazy_static;
 use mockall::predicate::{always, eq};
 use rstest::*;
+use starknet::providers::jsonrpc::HttpTransport;
+use starknet::providers::JsonRpcClient;
+use url::Url;
+
 use settlement_client_interface::MockSettlementClient;
 
-use color_eyre::eyre::eyre;
-use utils::env_utils::get_env_var_or_panic;
-
-use crate::config::config;
 use crate::constants::{BLOB_DATA_FILE_NAME, SNOS_OUTPUT_FILE_NAME};
 use crate::data_storage::MockDataStorage;
 use crate::jobs::constants::JOB_METADATA_STATE_UPDATE_LAST_FAILED_BLOCK_NO;
@@ -25,12 +27,8 @@ use crate::jobs::state_update_job::utils::hex_string_to_u8_vec;
 use crate::jobs::state_update_job::{StateUpdateError, StateUpdateJob};
 use crate::jobs::types::{JobStatus, JobType};
 use crate::jobs::{Job, JobError};
-use crate::tests::common::{default_job_item, get_storage_client};
+use crate::tests::common::default_job_item;
 use crate::tests::config::TestConfigBuilder;
-use lazy_static::lazy_static;
-use starknet::providers::jsonrpc::HttpTransport;
-use starknet::providers::JsonRpcClient;
-use url::Url;
 
 lazy_static! {
     pub static ref CURRENT_PATH: PathBuf = std::env::current_dir().unwrap();
@@ -43,12 +41,12 @@ pub const X_0_FILE_NAME: &str = "x_0.txt";
 #[rstest]
 #[tokio::test]
 async fn test_process_job_attempt_not_present_fails() {
-    TestConfigBuilder::new().build().await;
+    let services = TestConfigBuilder::new().build().await;
 
     let mut job = default_job_item();
-    let config = config().await;
+
     let state_update_job = StateUpdateJob {};
-    let res = state_update_job.process_job(&config, &mut job).await.unwrap_err();
+    let res = state_update_job.process_job(services.config, &mut job).await.unwrap_err();
     assert_eq!(res, JobError::StateUpdateJobError(StateUpdateError::AttemptNumberNotFound));
 }
 
@@ -63,9 +61,6 @@ async fn test_process_job_works(
 ) {
     // Will be used by storage client which we call while storing the data.
 
-    use num::ToPrimitive;
-
-    use crate::jobs::state_update_job::utils::fetch_blob_data_for_block;
     dotenvy::from_filename("../.env.test").expect("Failed to load the .env file");
 
     // Mocking the settlement client.
@@ -76,21 +71,17 @@ async fn test_process_job_works(
     // This must be the last block number and should be returned as an output from the process job.
     let last_block_number = block_numbers[block_numbers.len() - 1];
 
-    // Storing `blob_data` and `snos_output` in storage client
-    store_data_in_storage_client_for_s3(block_numbers.clone()).await;
-
-    // Building a temp config that will be used by `fetch_blob_data_for_block` and `fetch_snos_for_block`
-    // functions while fetching the blob data from storage client.
-    TestConfigBuilder::new().build().await;
-
-    // test_process_job_works uses nonce just to write expect_update_state_with_blobs for a mocked settlement client,
-    // which means that nonce ideally is never checked against, hence supplying any `u64` `nonce` works.
-    let nonce: u64 = 3;
-    settlement_client.expect_get_nonce().with().returning(move || Ok(nonce));
-
     // Adding expectations for each block number to be called by settlement client.
     for block in block_numbers.iter().skip(processing_start_index as usize) {
-        let blob_data = fetch_blob_data_for_block(block.to_u64().unwrap()).await.unwrap();
+        // Getting the blob data from file.
+        let blob_data = fs::read_to_string(
+            CURRENT_PATH.join(format!("src/tests/jobs/state_update_job/test_data/{}/{}", block, BLOB_DATA_FILE_NAME)),
+        )
+        .unwrap();
+
+        let blob_data_vec = vec![hex_string_to_u8_vec(&blob_data).unwrap()];
+
+        let blob_data = blob_data_vec;
         settlement_client
             .expect_update_state_with_blobs()
             .with(eq(vec![]), eq(blob_data), always())
@@ -98,9 +89,35 @@ async fn test_process_job_works(
             .returning(|_, _, _| Ok("0xbeef".to_string()));
     }
     settlement_client.expect_get_last_settled_block().with().returning(move || Ok(651052));
+    // Setting random nonce
+    settlement_client.expect_get_nonce().with().returning(move || Ok(2));
 
-    // Building new config with mocked settlement client
-    TestConfigBuilder::new().mock_settlement_client(Box::new(settlement_client)).build().await;
+    // Building a temp config that will be used by `fetch_blob_data_for_block` and `fetch_snos_for_block`
+    // functions while fetching the blob data from storage client.
+    let services = TestConfigBuilder::new().mock_settlement_client(Box::new(settlement_client)).build().await;
+
+    let storage_client = services.config.storage();
+
+    for block in block_numbers {
+        // Getting the blob data from file.
+        let blob_data_key = block.to_owned().to_string() + "/" + BLOB_DATA_FILE_NAME;
+        let blob_data = fs::read_to_string(
+            CURRENT_PATH.join(format!("src/tests/jobs/state_update_job/test_data/{}/{}", block, BLOB_DATA_FILE_NAME)),
+        )
+        .unwrap();
+        let blob_data_vec = vec![hex_string_to_u8_vec(&blob_data).unwrap()];
+        let blob_serialized = bincode::serialize(&blob_data_vec).unwrap();
+
+        // Getting the snos data from file.
+        let snos_output_key = block.to_owned().to_string() + "/" + SNOS_OUTPUT_FILE_NAME;
+        let snos_output_data = fs::read_to_string(
+            CURRENT_PATH.join(format!("src/tests/jobs/state_update_job/test_data/{}/{}", block, SNOS_OUTPUT_FILE_NAME)),
+        )
+        .unwrap();
+
+        storage_client.put_data(Bytes::from(snos_output_data), &snos_output_key).await.unwrap();
+        storage_client.put_data(Bytes::from(blob_serialized), &blob_data_key).await.unwrap();
+    }
 
     // setting last failed block number as 651053.
     // setting blocks yet to process as 651054 and 651055.
@@ -117,9 +134,8 @@ async fn test_process_job_works(
     job.job_type = JobType::StateTransition;
     job.metadata = metadata;
 
-    let config = config().await;
     let state_update_job = StateUpdateJob {};
-    let res = state_update_job.process_job(&config, &mut job).await.unwrap();
+    let res = state_update_job.process_job(services.config, &mut job).await.unwrap();
     assert_eq!(res, last_block_number.to_string());
 }
 
@@ -128,18 +144,16 @@ async fn test_process_job_works(
 #[rstest]
 #[tokio::test]
 async fn create_job_works() {
-    TestConfigBuilder::new().build().await;
+    let services = TestConfigBuilder::new().build().await;
 
-    let config = config().await;
-
-    let job = StateUpdateJob.create_job(&config, String::from("0"), HashMap::default()).await;
+    let job = StateUpdateJob.create_job(services.config, String::from("0"), HashMap::default()).await;
     assert!(job.is_ok());
 
     let job = job.unwrap();
     let job_type = job.job_type;
 
     assert_eq!(job_type, JobType::StateTransition, "job_type should be StateTransition");
-    assert!(!(job.id.is_nil()), "id should not be nil");
+    assert!(!job.id.is_nil(), "id should not be nil");
     assert_eq!(job.status, JobStatus::Created, "status should be Created");
     assert_eq!(job.version, 0_i32, "version should be 0");
     assert_eq!(job.external_id.unwrap_string().unwrap(), String::new(), "external_id should be empty string");
@@ -201,7 +215,7 @@ async fn process_job_works() {
             .returning(|_, _, _| Ok(String::from("0x5d17fac98d9454030426606019364f6e68d915b91f6210ef1e2628cd6987442")));
     }
 
-    TestConfigBuilder::new()
+    let services = TestConfigBuilder::new()
         .mock_settlement_client(Box::new(settlement_client))
         .mock_storage_client(Box::new(storage_client))
         .build()
@@ -213,8 +227,8 @@ async fn process_job_works() {
     metadata.insert(String::from(JOB_PROCESS_ATTEMPT_METADATA_KEY), String::from("0"));
 
     let mut job =
-        StateUpdateJob.create_job(config().await.as_ref(), String::from("internal_id"), metadata).await.unwrap();
-    assert_eq!(StateUpdateJob.process_job(config().await.as_ref(), &mut job).await.unwrap(), "651056".to_string())
+        StateUpdateJob.create_job(services.config.clone(), String::from("internal_id"), metadata).await.unwrap();
+    assert_eq!(StateUpdateJob.process_job(services.config, &mut job).await.unwrap(), "651056".to_string())
 }
 
 #[rstest]
@@ -232,19 +246,19 @@ async fn process_job_invalid_inputs_errors(#[case] block_numbers_to_settle: Stri
         Url::parse(format!("http://localhost:{}", server.port()).as_str()).expect("Failed to parse URL"),
     ));
 
-    TestConfigBuilder::new()
+    let services = TestConfigBuilder::new()
         .mock_starknet_client(Arc::new(provider))
         .mock_settlement_client(Box::new(settlement_client))
         .build()
         .await;
-    let config = config().await;
 
     let mut metadata: HashMap<String, String> = HashMap::new();
     metadata.insert(String::from(JOB_METADATA_STATE_UPDATE_BLOCKS_TO_SETTLE_KEY), block_numbers_to_settle);
     metadata.insert(String::from(JOB_PROCESS_ATTEMPT_METADATA_KEY), String::from("0"));
 
-    let mut job = StateUpdateJob.create_job(&config, String::from("internal_id"), metadata).await.unwrap();
-    let status = StateUpdateJob.process_job(&config, &mut job).await;
+    let mut job =
+        StateUpdateJob.create_job(services.config.clone(), String::from("internal_id"), metadata).await.unwrap();
+    let status = StateUpdateJob.process_job(services.config, &mut job).await;
     assert!(status.is_err());
 
     if let Err(error) = status {
@@ -269,7 +283,7 @@ async fn process_job_invalid_input_gap_panics() {
         Url::parse(format!("http://localhost:{}", server.port()).as_str()).expect("Failed to parse URL"),
     ));
 
-    TestConfigBuilder::new()
+    let services = TestConfigBuilder::new()
         .mock_starknet_client(Arc::new(provider))
         .mock_settlement_client(Box::new(settlement_client))
         .build()
@@ -280,8 +294,8 @@ async fn process_job_invalid_input_gap_panics() {
     metadata.insert(String::from(JOB_PROCESS_ATTEMPT_METADATA_KEY), String::from("0"));
 
     let mut job =
-        StateUpdateJob.create_job(config().await.as_ref(), String::from("internal_id"), metadata).await.unwrap();
-    let response = StateUpdateJob.process_job(config().await.as_ref(), &mut job).await;
+        StateUpdateJob.create_job(services.config.clone(), String::from("internal_id"), metadata).await.unwrap();
+    let response = StateUpdateJob.process_job(services.config, &mut job).await;
 
     assert_matches!(response,
         Err(e) => {
@@ -301,32 +315,6 @@ async fn load_state_diff_file(block_no: u64) -> Vec<Vec<u8>> {
     let blob_data = hex_string_to_u8_vec(&file_data).unwrap();
     state_diff_vec.push(blob_data);
     state_diff_vec
-}
-
-async fn store_data_in_storage_client_for_s3(block_numbers: Vec<u64>) {
-    let storage_client = get_storage_client().await;
-    storage_client.build_test_bucket(&get_env_var_or_panic("AWS_S3_BUCKET_NAME")).await.unwrap();
-
-    for block in block_numbers {
-        // Getting the blob data from file.
-        let blob_data_key = block.to_owned().to_string() + "/" + BLOB_DATA_FILE_NAME;
-        let blob_data = fs::read_to_string(
-            CURRENT_PATH.join(format!("src/tests/jobs/state_update_job/test_data/{}/{}", block, BLOB_DATA_FILE_NAME)),
-        )
-        .unwrap();
-        let blob_data_vec = vec![hex_string_to_u8_vec(&blob_data).unwrap()];
-        let blob_serialized = bincode::serialize(&blob_data_vec).unwrap();
-
-        // Getting the snos data from file.
-        let snos_output_key = block.to_owned().to_string() + "/" + SNOS_OUTPUT_FILE_NAME;
-        let snos_output_data = fs::read_to_string(
-            CURRENT_PATH.join(format!("src/tests/jobs/state_update_job/test_data/{}/{}", block, SNOS_OUTPUT_FILE_NAME)),
-        )
-        .unwrap();
-
-        storage_client.put_data(Bytes::from(snos_output_data), &snos_output_key).await.unwrap();
-        storage_client.put_data(Bytes::from(blob_serialized), &blob_data_key).await.unwrap();
-    }
 }
 
 fn parse_block_numbers(blocks_to_settle: &str) -> color_eyre::Result<Vec<u64>> {

--- a/crates/orchestrator/src/tests/jobs/state_update_job/mod.rs
+++ b/crates/orchestrator/src/tests/jobs/state_update_job/mod.rs
@@ -60,6 +60,8 @@ async fn test_process_job_works(
 ) {
     // Will be used by storage client which we call while storing the data.
 
+    use crate::tests::config::ClientValue;
+
     dotenvy::from_filename("../.env.test").expect("Failed to load the .env file");
 
     // Mocking the settlement client.
@@ -93,7 +95,11 @@ async fn test_process_job_works(
 
     // Building a temp config that will be used by `fetch_blob_data_for_block` and `fetch_snos_for_block`
     // functions while fetching the blob data from storage client.
-    let services = TestConfigBuilder::new().configure_settlement_client(settlement_client.into()).build().await;
+    let services = TestConfigBuilder::new()
+        .configure_storage_client(ClientValue::Actual)
+        .configure_settlement_client(settlement_client.into())
+        .build()
+        .await;
 
     let storage_client = services.config.storage();
 

--- a/crates/orchestrator/src/tests/jobs/state_update_job/mod.rs
+++ b/crates/orchestrator/src/tests/jobs/state_update_job/mod.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use assert_matches::assert_matches;
 use bytes::Bytes;
@@ -94,7 +93,7 @@ async fn test_process_job_works(
 
     // Building a temp config that will be used by `fetch_blob_data_for_block` and `fetch_snos_for_block`
     // functions while fetching the blob data from storage client.
-    let services = TestConfigBuilder::new().mock_settlement_client(Box::new(settlement_client)).build().await;
+    let services = TestConfigBuilder::new().configure_settlement_client(settlement_client.into()).build().await;
 
     let storage_client = services.config.storage();
 
@@ -216,8 +215,8 @@ async fn process_job_works() {
     }
 
     let services = TestConfigBuilder::new()
-        .mock_settlement_client(Box::new(settlement_client))
-        .mock_storage_client(Box::new(storage_client))
+        .configure_settlement_client(settlement_client.into())
+        .configure_storage_client(storage_client.into())
         .build()
         .await;
 
@@ -247,8 +246,8 @@ async fn process_job_invalid_inputs_errors(#[case] block_numbers_to_settle: Stri
     ));
 
     let services = TestConfigBuilder::new()
-        .mock_starknet_client(Arc::new(provider))
-        .mock_settlement_client(Box::new(settlement_client))
+        .configure_settlement_client(settlement_client.into())
+        .configure_starknet_client(provider.into())
         .build()
         .await;
 
@@ -284,8 +283,8 @@ async fn process_job_invalid_input_gap_panics() {
     ));
 
     let services = TestConfigBuilder::new()
-        .mock_starknet_client(Arc::new(provider))
-        .mock_settlement_client(Box::new(settlement_client))
+        .configure_starknet_client(provider.into())
+        .configure_settlement_client(settlement_client.into())
         .build()
         .await;
 

--- a/crates/orchestrator/src/tests/server/mod.rs
+++ b/crates/orchestrator/src/tests/server/mod.rs
@@ -62,5 +62,6 @@ async fn test_health_endpoint(#[future] setup_server: SocketAddr) {
 #[rstest]
 #[tokio::test]
 async fn test_init_consumer() {
-    assert!(init_consumers().await.is_ok());
+    let services = TestConfigBuilder::new().build().await;
+    assert!(init_consumers(services.config).await.is_ok());
 }

--- a/crates/orchestrator/src/tests/server/mod.rs
+++ b/crates/orchestrator/src/tests/server/mod.rs
@@ -1,6 +1,5 @@
 use std::io::Read;
 use std::net::SocketAddr;
-use std::sync::Arc;
 
 use axum::http::StatusCode;
 use hyper::body::Buf;
@@ -21,7 +20,7 @@ pub async fn setup_server() -> SocketAddr {
         Url::parse("http://localhost:9944".to_string().as_str()).expect("Failed to parse URL"),
     ));
 
-    TestConfigBuilder::new().mock_starknet_client(Arc::new(provider)).build().await;
+    TestConfigBuilder::new().configure_starknet_client(provider.into()).build().await;
 
     let host = get_env_var_or_default("HOST", "127.0.0.1");
     let port = get_env_var_or_default("PORT", "3000").parse::<u16>().expect("PORT must be a u16");

--- a/crates/orchestrator/src/tests/workers/proving/mod.rs
+++ b/crates/orchestrator/src/tests/workers/proving/mod.rs
@@ -92,12 +92,12 @@ async fn test_proving_worker(#[case] incomplete_runs: bool) -> Result<(), Box<dy
     ));
 
     let services = TestConfigBuilder::new()
-        .mock_starknet_client(Arc::new(provider))
-        .mock_db_client(Box::new(db))
-        .mock_queue(Box::new(queue))
-        .mock_da_client(Box::new(da_client))
-        .mock_prover_client(Box::new(prover_client))
-        .mock_settlement_client(Box::new(settlement_client))
+        .configure_starknet_client(provider.into())
+        .configure_database(db.into())
+        .configure_queue_client(queue.into())
+        .configure_da_client(da_client.into())
+        .configure_prover_client(prover_client.into())
+        .configure_settlement_client(settlement_client.into())
         .build()
         .await;
 

--- a/crates/orchestrator/src/tests/workers/proving/mod.rs
+++ b/crates/orchestrator/src/tests/workers/proving/mod.rs
@@ -29,7 +29,7 @@ async fn test_proving_worker(#[case] incomplete_runs: bool) -> Result<(), Box<dy
     let da_client = MockDaClient::new();
     let mut db = MockDatabase::new();
     let mut queue = MockQueueProvider::new();
-    let mut prover_client = MockProverClient::new();
+    let prover_client = MockProverClient::new();
     let settlement_client = MockSettlementClient::new();
 
     const JOB_PROCESSING_QUEUE: &str = "madara_orchestrator_job_processing_queue";
@@ -58,7 +58,7 @@ async fn test_proving_worker(#[case] incomplete_runs: bool) -> Result<(), Box<dy
             db_checks_proving_worker(i, &mut db, &mut job_handler);
         }
 
-        prover_client.expect_submit_task().times(4).returning(|_| Ok("task_id".to_string()));
+        // prover_client.expect_submit_task().times(4).returning(|_| Ok("task_id".to_string()));
 
         // Queue function call simulations
         queue
@@ -77,7 +77,7 @@ async fn test_proving_worker(#[case] incomplete_runs: bool) -> Result<(), Box<dy
             .withf(|_, _, _| true)
             .returning(move |_, _, _| Ok(get_job_by_mock_id_vector(JobType::ProofCreation, JobStatus::Created, 5, 1)));
 
-        prover_client.expect_submit_task().times(5).returning(|_| Ok("task_id".to_string()));
+        // prover_client.expect_submit_task().times(5).returning(|_| Ok("task_id".to_string()));
 
         // Queue function call simulations
         queue
@@ -91,7 +91,7 @@ async fn test_proving_worker(#[case] incomplete_runs: bool) -> Result<(), Box<dy
         Url::parse(format!("http://localhost:{}", server.port()).as_str()).expect("Failed to parse URL"),
     ));
 
-    TestConfigBuilder::new()
+    let services = TestConfigBuilder::new()
         .mock_starknet_client(Arc::new(provider))
         .mock_db_client(Box::new(db))
         .mock_queue(Box::new(queue))
@@ -111,7 +111,7 @@ async fn test_proving_worker(#[case] incomplete_runs: bool) -> Result<(), Box<dy
     }
 
     let proving_worker = ProvingWorker {};
-    proving_worker.run_worker().await?;
+    proving_worker.run_worker(services.config).await?;
 
     Ok(())
 }

--- a/crates/orchestrator/src/tests/workers/snos/mod.rs
+++ b/crates/orchestrator/src/tests/workers/snos/mod.rs
@@ -95,7 +95,7 @@ async fn test_snos_worker(#[case] db_val: bool) -> Result<(), Box<dyn Error>> {
         Url::parse(format!("http://localhost:{}", server.port()).as_str()).expect("Failed to parse URL"),
     ));
 
-    TestConfigBuilder::new()
+    let services = TestConfigBuilder::new()
         .mock_starknet_client(Arc::new(provider))
         .mock_db_client(Box::new(db))
         .mock_queue(Box::new(queue))
@@ -110,7 +110,7 @@ async fn test_snos_worker(#[case] db_val: bool) -> Result<(), Box<dyn Error>> {
     });
 
     let snos_worker = SnosWorker {};
-    snos_worker.run_worker().await?;
+    snos_worker.run_worker(services.config).await?;
 
     rpc_block_call_mock.assert();
 

--- a/crates/orchestrator/src/tests/workers/snos/mod.rs
+++ b/crates/orchestrator/src/tests/workers/snos/mod.rs
@@ -96,10 +96,10 @@ async fn test_snos_worker(#[case] db_val: bool) -> Result<(), Box<dyn Error>> {
     ));
 
     let services = TestConfigBuilder::new()
-        .mock_starknet_client(Arc::new(provider))
-        .mock_db_client(Box::new(db))
-        .mock_queue(Box::new(queue))
-        .mock_da_client(Box::new(da_client))
+        .configure_starknet_client(provider.into())
+        .configure_database(db.into())
+        .configure_queue_client(queue.into())
+        .configure_da_client(da_client.into())
         .build()
         .await;
 

--- a/crates/orchestrator/src/tests/workers/update_state/mod.rs
+++ b/crates/orchestrator/src/tests/workers/update_state/mod.rs
@@ -70,12 +70,10 @@ async fn test_update_state_worker(
         // creation)
         let completed_jobs =
             get_job_by_mock_id_vector(JobType::ProofCreation, JobStatus::Completed, number_of_processed_jobs as u64, 2);
-        for job in completed_jobs {
-            db.expect_get_job_by_internal_id_and_type()
-                .times(1)
-                .with(eq(job.internal_id.to_string()), eq(JobType::StateTransition))
-                .returning(|_, _| Ok(None));
-        }
+        db.expect_get_job_by_internal_id_and_type()
+            .times(1)
+            .with(eq(completed_jobs[0].internal_id.to_string()), eq(JobType::StateTransition))
+            .returning(|_, _| Ok(None));
 
         // mocking the creation of jobs
         let job_item = get_job_item_mock_by_id("1".to_string(), Uuid::new_v4());
@@ -107,7 +105,7 @@ async fn test_update_state_worker(
     ));
 
     // mock block number (madara) : 5
-    TestConfigBuilder::new()
+    let services = TestConfigBuilder::new()
         .mock_starknet_client(Arc::new(provider))
         .mock_db_client(Box::new(db))
         .mock_queue(Box::new(queue))
@@ -116,7 +114,7 @@ async fn test_update_state_worker(
         .await;
 
     let update_state_worker = UpdateStateWorker {};
-    update_state_worker.run_worker().await?;
+    update_state_worker.run_worker(services.config).await?;
 
     Ok(())
 }

--- a/crates/orchestrator/src/tests/workers/update_state/mod.rs
+++ b/crates/orchestrator/src/tests/workers/update_state/mod.rs
@@ -106,10 +106,10 @@ async fn test_update_state_worker(
 
     // mock block number (madara) : 5
     let services = TestConfigBuilder::new()
-        .mock_starknet_client(Arc::new(provider))
-        .mock_db_client(Box::new(db))
-        .mock_queue(Box::new(queue))
-        .mock_da_client(Box::new(da_client))
+        .configure_starknet_client(provider.into())
+        .configure_database(db.into())
+        .configure_queue_client(queue.into())
+        .configure_da_client(da_client.into())
         .build()
         .await;
 

--- a/crates/orchestrator/src/workers/data_submission_worker.rs
+++ b/crates/orchestrator/src/workers/data_submission_worker.rs
@@ -1,10 +1,11 @@
-use crate::config::config;
+use crate::config::Config;
 use crate::jobs::create_job;
 use crate::jobs::types::{JobStatus, JobType};
 use crate::workers::Worker;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::error::Error;
+use std::sync::Arc;
 
 pub struct DataSubmissionWorker;
 
@@ -14,9 +15,7 @@ impl Worker for DataSubmissionWorker {
     // 1. Fetch the latest completed Proving job.
     // 2. Fetch the latest DA job creation.
     // 3. Create jobs from after the lastest DA job already created till latest completed proving job.
-    async fn run_worker(&self) -> Result<(), Box<dyn Error>> {
-        let config = config().await;
-
+    async fn run_worker(&self, config: Arc<Config>) -> Result<(), Box<dyn Error>> {
         // provides latest completed proof creation job id
         let latest_proven_job_id = config
             .database()
@@ -40,7 +39,7 @@ impl Worker for DataSubmissionWorker {
 
         // creating data submission jobs for latest blocks that don't have existing data submission jobs yet.
         for new_job_id in latest_data_submission_id + 1..latest_proven_id + 1 {
-            create_job(JobType::DataSubmission, new_job_id.to_string(), HashMap::new()).await?;
+            create_job(JobType::DataSubmission, new_job_id.to_string(), HashMap::new(), config.clone()).await?;
         }
 
         Ok(())

--- a/crates/orchestrator/src/workers/mod.rs
+++ b/crates/orchestrator/src/workers/mod.rs
@@ -1,6 +1,6 @@
-use crate::{config::config, jobs::types::JobStatus};
+use crate::{config::Config, jobs::types::JobStatus};
 use async_trait::async_trait;
-use std::error::Error;
+use std::{error::Error, sync::Arc};
 
 pub mod data_submission_worker;
 pub mod proof_registration;
@@ -10,14 +10,14 @@ pub mod update_state;
 
 #[async_trait]
 pub trait Worker: Send + Sync {
-    async fn run_worker_if_enabled(&self) -> Result<(), Box<dyn Error>> {
-        if !self.is_worker_enabled().await? {
+    async fn run_worker_if_enabled(&self, config: Arc<Config>) -> Result<(), Box<dyn Error>> {
+        if !self.is_worker_enabled(config.clone()).await? {
             return Ok(());
         }
-        self.run_worker().await
+        self.run_worker(config).await
     }
 
-    async fn run_worker(&self) -> Result<(), Box<dyn Error>>;
+    async fn run_worker(&self, config: Arc<Config>) -> Result<(), Box<dyn Error>>;
 
     // Assumption
     // If say a job for block X fails, we don't want the worker to respawn another job for the same block
@@ -29,9 +29,7 @@ pub trait Worker: Send + Sync {
     // Checks if any of the jobs have failed
     // Failure : JobStatus::VerificationFailed, JobStatus::VerificationTimeout, JobStatus::Failed
     // Halts any new job creation till all the count of failed jobs is not Zero.
-    async fn is_worker_enabled(&self) -> Result<bool, Box<dyn Error>> {
-        let config = config().await;
-
+    async fn is_worker_enabled(&self, config: Arc<Config>) -> Result<bool, Box<dyn Error>> {
         let failed_jobs = config
             .database()
             .get_jobs_by_statuses(vec![JobStatus::VerificationFailed, JobStatus::VerificationTimeout], Some(1))

--- a/crates/orchestrator/src/workers/proof_registration.rs
+++ b/crates/orchestrator/src/workers/proof_registration.rs
@@ -1,8 +1,8 @@
-use std::error::Error;
+use std::{error::Error, sync::Arc};
 
 use async_trait::async_trait;
 
-use crate::workers::Worker;
+use crate::{config::Config, workers::Worker};
 
 pub struct ProofRegistrationWorker;
 
@@ -11,7 +11,7 @@ impl Worker for ProofRegistrationWorker {
     /// 1. Fetch all blocks with a successful proving job run
     /// 2. Group blocks that have the same proof
     /// 3. For each group, create a proof registration job with from and to block in metadata
-    async fn run_worker(&self) -> Result<(), Box<dyn Error>> {
+    async fn run_worker(&self, _config: Arc<Config>) -> Result<(), Box<dyn Error>> {
         todo!()
     }
 }

--- a/crates/orchestrator/src/workers/proving.rs
+++ b/crates/orchestrator/src/workers/proving.rs
@@ -1,9 +1,10 @@
-use crate::config::config;
+use crate::config::Config;
 use crate::jobs::create_job;
 use crate::jobs::types::{JobStatus, JobType};
 use crate::workers::Worker;
 use async_trait::async_trait;
 use std::error::Error;
+use std::sync::Arc;
 
 pub struct ProvingWorker;
 
@@ -11,15 +12,14 @@ pub struct ProvingWorker;
 impl Worker for ProvingWorker {
     /// 1. Fetch all successful SNOS job runs that don't have a proving job
     /// 2. Create a proving job for each SNOS job run
-    async fn run_worker(&self) -> Result<(), Box<dyn Error>> {
-        let config = config().await;
+    async fn run_worker(&self, config: Arc<Config>) -> Result<(), Box<dyn Error>> {
         let successful_snos_jobs = config
             .database()
             .get_jobs_without_successor(JobType::SnosRun, JobStatus::Completed, JobType::ProofCreation)
             .await?;
 
         for job in successful_snos_jobs {
-            create_job(JobType::ProofCreation, job.internal_id.to_string(), job.metadata).await?
+            create_job(JobType::ProofCreation, job.internal_id.to_string(), job.metadata, config.clone()).await?
         }
 
         Ok(())


### PR DESCRIPTION
# This PR solves #110.

- Creates `new` for `alert_client` and generalises `Region` to `AWS_REGION` removing usage of `AWS_SNS_REGION`.
- Ensures no excess access to AWS_ENV_VARS other than `init_config` and `testconfigbuilder`.