### PR TITLE
Improvement/better alert

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -26,7 +26,6 @@ SQS_WORKER_TRIGGER_QUEUE_URL="http://sqs.us-east-1.localhost.localstack.cloud:45
 
 ##### SNS #####
 ALERTS="sns"
-AWS_SNS_REGION="us-east-1"
 AWS_SNS_ARN="arn:aws:sns:us-east-1:000000000000:madara-orchestrator-arn"
 AWS_SNS_ARN_NAME="madara-orchestrator-arn"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Changed
 
+- AWS config built from TestConfigBuilder.
 - Better TestConfigBuilder, with sync config clients.
 - Drilled Config, removing dirty global reads.
 - refactor AWS config usage and clean .env files

--- a/crates/orchestrator/src/alerts/aws_sns/mod.rs
+++ b/crates/orchestrator/src/alerts/aws_sns/mod.rs
@@ -13,12 +13,6 @@ impl AWSSNS {
     pub async fn new(config: &SdkConfig) -> Self {
         AWSSNS { client: Client::new(config) }
     }
-
-    /// To create a new SNS client from the environment variables
-    pub async fn new_from_env() -> Self {
-        let config = aws_config::from_env().load().await;
-        AWSSNS { client: Client::new(&config) }
-    }
 }
 
 #[async_trait]

--- a/crates/orchestrator/src/alerts/aws_sns/mod.rs
+++ b/crates/orchestrator/src/alerts/aws_sns/mod.rs
@@ -1,6 +1,6 @@
 use crate::alerts::Alerts;
 use async_trait::async_trait;
-use aws_sdk_sns::config::Region;
+use aws_config::SdkConfig;
 use aws_sdk_sns::Client;
 use utils::env_utils::get_env_var_or_panic;
 
@@ -10,9 +10,13 @@ pub struct AWSSNS {
 
 impl AWSSNS {
     /// To create a new SNS client
-    pub async fn new() -> Self {
-        let sns_region = get_env_var_or_panic("AWS_SNS_REGION");
-        let config = aws_config::from_env().region(Region::new(sns_region)).load().await;
+    pub async fn new(config: &SdkConfig) -> Self {
+        AWSSNS { client: Client::new(config) }
+    }
+
+    /// To create a new SNS client from the environment variables
+    pub async fn new_from_env() -> Self {
+        let config = aws_config::from_env().load().await;
         AWSSNS { client: Client::new(&config) }
     }
 }

--- a/crates/orchestrator/src/tests/alerts/mod.rs
+++ b/crates/orchestrator/src/tests/alerts/mod.rs
@@ -20,7 +20,7 @@ async fn sns_alert_subscribe_to_topic_receive_alert_works() {
     let queue = sqs_client.create_queue().queue_name(SNS_ALERT_TEST_QUEUE).send().await.unwrap();
     let queue_url = queue.queue_url().unwrap();
 
-    let sns_client = get_sns_client().await;
+    let sns_client = get_sns_client(&services.aws_config).await;
 
     let queue_attributes =
         sqs_client.get_queue_attributes().queue_url(queue_url).attribute_names(QueueArn).send().await.unwrap();

--- a/crates/orchestrator/src/tests/common/mod.rs
+++ b/crates/orchestrator/src/tests/common/mod.rs
@@ -3,7 +3,7 @@ pub mod constants;
 use std::collections::HashMap;
 
 use ::uuid::Uuid;
-use aws_config::Region;
+use aws_config::{Region, SdkConfig};
 use aws_sdk_sns::error::SdkError;
 use aws_sdk_sns::operation::create_topic::CreateTopicError;
 use mongodb::Client;
@@ -43,16 +43,14 @@ pub fn custom_job_item(default_job_item: JobItem, #[default(String::from("0"))] 
     job_item
 }
 
-pub async fn create_sns_arn() -> Result<(), SdkError<CreateTopicError>> {
-    let sns_client = get_sns_client().await;
+pub async fn create_sns_arn(aws_config: &SdkConfig) -> Result<(), SdkError<CreateTopicError>> {
+    let sns_client = get_sns_client(aws_config).await;
     sns_client.create_topic().name(get_env_var_or_panic("AWS_SNS_ARN_NAME")).send().await?;
     Ok(())
 }
 
-pub async fn get_sns_client() -> aws_sdk_sns::client::Client {
-    let sns_region = get_env_var_or_panic("AWS_SNS_REGION");
-    let config = aws_config::from_env().region(Region::new(sns_region)).load().await;
-    aws_sdk_sns::Client::new(&config)
+pub async fn get_sns_client(aws_config: &SdkConfig) -> aws_sdk_sns::client::Client {
+    aws_sdk_sns::Client::new(aws_config)
 }
 
 pub async fn drop_database() -> color_eyre::Result<()> {

--- a/crates/orchestrator/src/tests/config.rs
+++ b/crates/orchestrator/src/tests/config.rs
@@ -76,22 +76,22 @@ impl_mock_from! {
 // TestBuilder for Config
 pub struct TestConfigBuilder {
     /// The starknet client to get data from the node
-    starknet_client_option: ConfigType,
+    starknet_client_type: ConfigType,
     /// The DA client to interact with the DA layer
-    da_client_option: ConfigType,
+    da_client_type: ConfigType,
     /// The service that produces proof and registers it on chain
-    prover_client_option: ConfigType,
+    prover_client_type: ConfigType,
     /// Settlement client
-    settlement_client_option: ConfigType,
+    settlement_client_type: ConfigType,
 
     /// Alerts client
-    alerts_option: ConfigType,
+    alerts_type: ConfigType,
     /// The database client
-    database_option: ConfigType,
+    database_type: ConfigType,
     /// Queue client
-    queue_option: ConfigType,
+    queue_type: ConfigType,
     /// Storage client
-    storage_option: ConfigType,
+    storage_type: ConfigType,
 }
 
 impl Default for TestConfigBuilder {
@@ -109,53 +109,53 @@ impl TestConfigBuilder {
     /// Create a new config
     pub fn new() -> TestConfigBuilder {
         TestConfigBuilder {
-            starknet_client_option: ConfigType::Dummy,
-            da_client_option: ConfigType::Dummy,
-            prover_client_option: ConfigType::Dummy,
-            settlement_client_option: ConfigType::Dummy,
-            database_option: ConfigType::Dummy,
-            queue_option: ConfigType::Dummy,
-            storage_option: ConfigType::Dummy,
-            alerts_option: ConfigType::Dummy,
+            starknet_client_type: ConfigType::Dummy,
+            da_client_type: ConfigType::Dummy,
+            prover_client_type: ConfigType::Dummy,
+            settlement_client_type: ConfigType::Dummy,
+            database_type: ConfigType::Dummy,
+            queue_type: ConfigType::Dummy,
+            storage_type: ConfigType::Dummy,
+            alerts_type: ConfigType::Dummy,
         }
     }
 
-    pub fn configure_da_client(mut self, da_client_option: ConfigType) -> TestConfigBuilder {
-        self.da_client_option = da_client_option;
+    pub fn configure_da_client(mut self, da_client_type: ConfigType) -> TestConfigBuilder {
+        self.da_client_type = da_client_type;
         self
     }
 
-    pub fn configure_settlement_client(mut self, settlement_client_option: ConfigType) -> TestConfigBuilder {
-        self.settlement_client_option = settlement_client_option;
+    pub fn configure_settlement_client(mut self, settlement_client_type: ConfigType) -> TestConfigBuilder {
+        self.settlement_client_type = settlement_client_type;
         self
     }
 
-    pub fn configure_starknet_client(mut self, starknet_client_option: ConfigType) -> TestConfigBuilder {
-        self.starknet_client_option = starknet_client_option;
+    pub fn configure_starknet_client(mut self, starknet_client_type: ConfigType) -> TestConfigBuilder {
+        self.starknet_client_type = starknet_client_type;
         self
     }
 
-    pub fn configure_prover_client(mut self, prover_client_option: ConfigType) -> TestConfigBuilder {
-        self.prover_client_option = prover_client_option;
+    pub fn configure_prover_client(mut self, prover_client_type: ConfigType) -> TestConfigBuilder {
+        self.prover_client_type = prover_client_type;
         self
     }
 
     pub fn configure_alerts(mut self, alert_option: ConfigType) -> TestConfigBuilder {
-        self.alerts_option = alert_option;
+        self.alerts_type = alert_option;
         self
     }
 
     pub fn configure_storage_client(mut self, storage_client_option: ConfigType) -> TestConfigBuilder {
-        self.storage_option = storage_client_option;
+        self.storage_type = storage_client_option;
         self
     }
 
-    pub fn configure_queue_client(mut self, queue_option: ConfigType) -> TestConfigBuilder {
-        self.queue_option = queue_option;
+    pub fn configure_queue_client(mut self, queue_type: ConfigType) -> TestConfigBuilder {
+        self.queue_type = queue_type;
         self
     }
-    pub fn configure_database(mut self, database_option: ConfigType) -> TestConfigBuilder {
-        self.database_option = database_option;
+    pub fn configure_database(mut self, database_type: ConfigType) -> TestConfigBuilder {
+        self.database_type = database_type;
         self
     }
 
@@ -167,28 +167,28 @@ impl TestConfigBuilder {
         use std::sync::Arc;
 
         let TestConfigBuilder {
-            starknet_client_option,
-            alerts_option,
-            da_client_option,
-            prover_client_option,
-            settlement_client_option,
-            database_option,
-            queue_option,
-            storage_option,
+            starknet_client_type,
+            alerts_type,
+            da_client_type,
+            prover_client_type,
+            settlement_client_type,
+            database_type,
+            queue_type,
+            storage_type,
         } = self;
 
-        let (starknet_client, server) = init_starknet_client(starknet_client_option).await;
-        let alerts = init_alerts(alerts_option).await;
-        let da_client = init_da_client(da_client_option).await;
+        let (starknet_client, server) = init_starknet_client(starknet_client_type).await;
+        let alerts = init_alerts(alerts_type, &aws_config).await;
+        let da_client = init_da_client(da_client_type).await;
 
-        let settlement_client = init_settlement_client(settlement_client_option).await;
+        let settlement_client = init_settlement_client(settlement_client_type).await;
 
-        let prover_client = init_prover_client(prover_client_option).await;
+        let prover_client = init_prover_client(prover_client_type).await;
 
         // External Dependencies
-        let storage = init_storage_client(storage_option).await;
-        let database = init_database(database_option).await;
-        let queue = init_queue_client(queue_option).await;
+        let storage = init_storage_client(storage_type).await;
+        let database = init_database(database_type).await;
+        let queue = init_queue_client(queue_type).await;
         // Deleting and Creating the queues in sqs.
         create_sqs_queues().await.expect("Not able to delete and create the queues.");
         // Deleting the database


### PR DESCRIPTION
# This PR solves #110.
# This PR is a clone of [PR 111](https://github.com/madara-alliance/madara-orchestrator/pull/111) that was accidentally merged to main (reverted now).

- Creates `new` for `alert_client` and generalises `Region` to `AWS_REGION` removing usage of `AWS_SNS_REGION`.
- Ensures no excess access to AWS_ENV_VARS other than `init_config` and `testconfigbuilder`.

