### PR TITLE
workspace oriented dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,5 +45,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Fixed
 
+- Cargo.toml dependency reorg.
 - Get Fact Info logic.
 - Fixed state update worker logic as per the new implementation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
  "alloy-signer-wallet",
  "alloy-transport 0.1.0",
  "alloy-transport-http 0.1.0",
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
 ]
 
 [[package]]
@@ -443,7 +443,7 @@ dependencies = [
  "dashmap",
  "futures",
  "lru",
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
  "serde_json",
  "tokio",
  "tracing",
@@ -480,7 +480,7 @@ dependencies = [
  "futures-utils-wasm",
  "lru",
  "pin-project",
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
  "serde",
  "serde_json",
  "tokio",
@@ -539,7 +539,7 @@ dependencies = [
  "alloy-transport-http 0.1.0",
  "futures",
  "pin-project",
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
  "serde",
  "serde_json",
  "tokio",
@@ -564,7 +564,7 @@ dependencies = [
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
  "serde",
  "serde_json",
  "tokio",
@@ -897,7 +897,7 @@ source = "git+https://github.com/alloy-rs/alloy?rev=68952c0#68952c00372b4c388c7e
 dependencies = [
  "alloy-json-rpc 0.1.0",
  "alloy-transport 0.1.0",
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
  "serde_json",
  "tower",
  "url",
@@ -911,7 +911,7 @@ checksum = "2437d145d80ea1aecde8574d2058cceb8b3c9cba05f6aea8e67907c660d46698"
 dependencies = [
  "alloy-json-rpc 0.2.1",
  "alloy-transport 0.2.1",
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
  "serde_json",
  "tower",
  "tracing",
@@ -2339,7 +2339,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.66",
  "which",
@@ -3238,7 +3238,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits 0.2.19",
  "serde",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3563,7 +3563,7 @@ dependencies = [
  "async-trait",
  "axum 0.7.5",
  "color-eyre",
- "mockall 0.12.1",
+ "mockall",
  "starknet",
 ]
 
@@ -3886,12 +3886,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
-
-[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3932,7 +3926,7 @@ name = "e2e-tests"
 version = "0.1.0"
 dependencies = [
  "orchestrator",
- "reqwest 0.11.27",
+ "reqwest 0.12.7",
  "serde_json",
  "testcontainers",
  "tokio",
@@ -4137,9 +4131,9 @@ dependencies = [
  "c-kzg",
  "color-eyre",
  "da-client-interface",
- "dotenv",
- "mockall 0.12.1",
- "reqwest 0.12.5",
+ "dotenvy",
+ "mockall",
+ "reqwest 0.12.7",
  "rstest 0.18.2",
  "serde",
  "starknet",
@@ -4158,11 +4152,10 @@ dependencies = [
  "async-trait",
  "c-kzg",
  "color-eyre",
- "dotenv",
  "dotenvy",
  "lazy_static",
- "mockall 0.12.1",
- "reqwest 0.12.5",
+ "mockall",
+ "reqwest 0.12.7",
  "rstest 0.18.2",
  "serde",
  "settlement-client-interface",
@@ -5128,6 +5121,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.0",
  "tower-service",
+ "webpki-roots 0.26.3",
 ]
 
 [[package]]
@@ -5404,7 +5398,7 @@ dependencies = [
  "socket2 0.5.7",
  "widestring",
  "windows-sys 0.48.0",
- "winreg 0.50.0",
+ "winreg",
 ]
 
 [[package]]
@@ -5672,7 +5666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5950,21 +5944,6 @@ checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "mockall"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
-dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "lazy_static",
- "mockall_derive 0.12.1",
- "predicates",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4c28b3fb6d753d28c20e826cd46ee611fda1cf3cde03a443a974043247c065a"
@@ -5972,21 +5951,9 @@ dependencies = [
  "cfg-if",
  "downcast",
  "fragile",
- "mockall_derive 0.13.0",
+ "mockall_derive",
  "predicates",
  "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
 ]
 
 [[package]]
@@ -6419,7 +6386,7 @@ dependencies = [
  "log",
  "majin-blob-core",
  "majin-blob-types",
- "mockall 0.13.0",
+ "mockall",
  "mockall_double",
  "mongodb",
  "num",
@@ -6574,7 +6541,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.2",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7133,7 +7100,7 @@ dependencies = [
  "async-trait",
  "cairo-vm 1.0.0-rc3",
  "gps-fact-checker",
- "mockall 0.12.1",
+ "mockall",
  "snos",
  "thiserror",
  "utils",
@@ -7144,6 +7111,54 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quinn"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.0.0",
+ "rustls 0.23.10",
+ "socket2 0.5.7",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash 2.0.0",
+ "rustls 0.23.10",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2 0.5.7",
+ "tracing",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "quote"
@@ -7374,7 +7389,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.24.1",
@@ -7384,14 +7399,14 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 0.25.4",
- "winreg 0.50.0",
+ "winreg",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.5"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7415,20 +7430,25 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.10",
  "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
- "system-configuration",
+ "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.26.0",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg 0.52.0",
+ "webpki-roots 0.26.3",
+ "windows-registry",
 ]
 
 [[package]]
@@ -7622,6 +7642,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustc-hex"
@@ -7865,7 +7891,7 @@ dependencies = [
  "log",
  "oorandom",
  "parking_lot 0.11.2",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "salsa-macros",
  "smallvec",
 ]
@@ -8285,7 +8311,7 @@ dependencies = [
  "axum 0.7.5",
  "c-kzg",
  "color-eyre",
- "mockall 0.12.1",
+ "mockall",
  "starknet",
 ]
 
@@ -8371,7 +8397,7 @@ dependencies = [
  "httpmock",
  "lazy_static",
  "prover-client-interface",
- "reqwest 0.11.27",
+ "reqwest 0.12.7",
  "rstest 0.18.2",
  "serde",
  "serde_json",
@@ -8813,10 +8839,9 @@ dependencies = [
  "async-trait",
  "c-kzg",
  "color-eyre",
- "dotenv",
  "lazy_static",
- "mockall 0.12.1",
- "reqwest 0.12.5",
+ "mockall",
+ "reqwest 0.12.7",
  "rstest 0.18.2",
  "serde",
  "settlement-client-interface",
@@ -9058,6 +9083,9 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -9078,7 +9106,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.5.0",
+ "core-foundation",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -9086,6 +9125,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -9161,7 +9210,7 @@ dependencies = [
  "log",
  "memchr",
  "parse-display",
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
  "serde",
  "serde_json",
  "serde_with 3.8.1",
@@ -10086,7 +10135,37 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -10104,7 +10183,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -10124,18 +10203,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -10146,9 +10225,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -10158,9 +10237,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10170,15 +10249,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -10188,9 +10267,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -10200,9 +10279,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -10212,9 +10291,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -10224,9 +10303,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -10251,16 +10330,6 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,13 @@ dotenvy = "0.15.7"
 futures = "0.3.30"
 mongodb = { version = "2.8.1" }
 omniqueue = { version = "0.2.0" }
-reqwest = { version = "0.11.24", features = ["rustls-tls", "native-tls"] }
+reqwest = { version = "0.12.7", features = [
+  "rustls-tls",
+  "native-tls",
+  "json",
+] }
 rstest = "0.18.2"
-serde = { version = "1.0.197" }
+serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
 starknet = "0.9.0"
 tempfile = "3.8.1"
@@ -50,13 +54,13 @@ url = { version = "2.5.0", features = ["serde"] }
 uuid = { version = "1.7.0", features = ["v4", "serde"] }
 httpmock = { version = "0.7.0", features = ["remote"] }
 num-bigint = { version = "0.4.4" }
-arc-swap = { version = "1.7.1" }
+arc-swap = { version = "1.7.0" }
 num-traits = "0.2"
 lazy_static = "1.4.0"
 stark_evm_adapter = "0.1.1"
 hex = "0.4"
 itertools = "0.13.0"
-mockall = "0.12.1"
+mockall = "0.13.0"
 testcontainers = "0.18.0"
 
 # Cairo VM

--- a/crates/da-clients/ethereum/Cargo.toml
+++ b/crates/da-clients/ethereum/Cargo.toml
@@ -15,14 +15,14 @@ alloy = { git = "https://github.com/alloy-rs/alloy", rev = "68952c0", features =
   "signer-wallet",
 ] }
 async-trait = { workspace = true }
-c-kzg = "1.0.0"
+c-kzg = { workspace = true }
 color-eyre = { workspace = true }
 da-client-interface = { workspace = true }
-dotenv = "0.15"
-mockall = "0.12.1"
-reqwest = { version = "0.12.3" }
+dotenvy.workspace = true
+mockall = { workspace = true }
+reqwest = { workspace = true }
 rstest = { workspace = true }
-serde = { version = "1.0.196", default-features = false, features = ["derive"] }
+serde = { workspace = true, default-features = false, features = ["derive"] }
 starknet = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -38,7 +38,7 @@ lazy_static = { workspace = true }
 log = "0.4.21"
 majin-blob-core = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
 majin-blob-types = { git = "https://github.com/AbdelStark/majin-blob", branch = "main" }
-mockall = { version = "0.13.0" }
+mockall = { workspace = true }
 mockall_double = "0.3.1"
 mongodb = { workspace = true, features = ["bson-uuid-1"], optional = true }
 num = { workspace = true }
@@ -71,7 +71,6 @@ with_mongodb = ["mongodb"]
 with_sqs = ["omniqueue"]
 
 [dev-dependencies]
-assert_matches = "1.5.0"
 hyper = { version = "0.14", features = ["full"] }
 rstest = { workspace = true }
 httpmock = { workspace = true, features = ["remote"] }

--- a/crates/orchestrator/src/data_storage/mod.rs
+++ b/crates/orchestrator/src/data_storage/mod.rs
@@ -25,6 +25,6 @@ pub trait DataStorage: Send + Sync {
 /// initialisation of data storage client
 pub trait DataStorageConfig {
     /// Get a config file from environment vars in system or
-    /// dotenv file.
+    /// env file.
     fn new_from_env() -> Self;
 }

--- a/crates/settlement-clients/ethereum/Cargo.toml
+++ b/crates/settlement-clients/ethereum/Cargo.toml
@@ -4,18 +4,18 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-alloy = { workspace = true, features = ["full", "node-bindings"] }
 alloy-primitives = { version = "0.7.7", default-features = false }
+
+alloy = { workspace = true, features = ["full", "node-bindings"] }
 async-trait = { workspace = true }
-c-kzg = "1.0.0"
+c-kzg = { workspace = true }
 color-eyre = { workspace = true }
-dotenv = "0.15"
 dotenvy = { workspace = true }
-lazy_static = "1.4.0"
-mockall = "0.12.1"
-reqwest = { version = "0.12.3" }
+lazy_static = { workspace = true }
+mockall = { workspace = true }
+reqwest = { workspace = true }
 rstest = { workspace = true }
-serde = { version = "1.0.196", default-features = false, features = ["derive"] }
+serde = { workspace = true, default-features = false, features = ["derive"] }
 settlement-client-interface = { workspace = true }
 snos = { workspace = true }
 tokio = { workspace = true }

--- a/crates/settlement-clients/ethereum/src/lib.rs
+++ b/crates/settlement-clients/ethereum/src/lib.rs
@@ -22,7 +22,8 @@ use async_trait::async_trait;
 use c_kzg::{Blob, Bytes32, KzgCommitment, KzgProof, KzgSettings};
 use color_eyre::eyre::{eyre, Ok};
 use color_eyre::Result;
-use mockall::{automock, lazy_static, predicate::*};
+use lazy_static::lazy_static;
+use mockall::{automock, predicate::*};
 
 use alloy::providers::ProviderBuilder;
 use conversion::{get_input_data_for_eip_4844, prepare_sidecar};

--- a/crates/settlement-clients/settlement-client-interface/Cargo.toml
+++ b/crates/settlement-clients/settlement-client-interface/Cargo.toml
@@ -11,5 +11,5 @@ async-trait = { workspace = true }
 axum = { workspace = true }
 c-kzg = { workspace = true }
 color-eyre = { workspace = true }
-mockall = "0.12.1"
+mockall = { workspace = true }
 starknet = { workspace = true }

--- a/crates/settlement-clients/starknet/Cargo.toml
+++ b/crates/settlement-clients/starknet/Cargo.toml
@@ -5,12 +5,11 @@ edition.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
-c-kzg = "1.0.0"
+c-kzg = { workspace = true }
 color-eyre = { workspace = true }
-dotenv = "0.15"
 lazy_static = { workspace = true }
-mockall = "0.12.1"
-reqwest = { version = "0.12.3" }
+mockall = { workspace = true }
+reqwest = { workspace = true }
 rstest = { workspace = true }
 serde = { workspace = true }
 settlement-client-interface = { workspace = true }

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-orchestrator.workspace = true
 reqwest = { workspace = true, features = ["json"] }
+tokio = { workspace = true, features = ["full"] }
+orchestrator.workspace = true
 serde_json.workspace = true
 testcontainers.workspace = true
-tokio = { workspace = true, features = ["full"] }
 tokio-stream.workspace = true
 tokio-util.workspace = true
 url.workspace = true

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-reqwest = { workspace = true, features = ["json"] }
-tokio = { workspace = true, features = ["full"] }
 orchestrator.workspace = true
+reqwest = { workspace = true, features = ["json"] }
 serde_json.workspace = true
 testcontainers.workspace = true
+tokio = { workspace = true, features = ["full"] }
 tokio-stream.workspace = true
 tokio-util.workspace = true
 url.workspace = true


### PR DESCRIPTION
# This PR resolves issue #99

Going with this convention for PR : 
- If a dependencies is only being used in a single crate and it's specific to that crate then no need to move it to workspace dependency.
- If a dependency is being used in multiple crates but with different features then it should be defined as a workspace dependency and individual features must be pulled in each crate.
- If any dependency is being used in many crates without any `ifs and buts` then we define it as a workspace dependency.
