### PR TITLE
Change layout of snos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Fixed
 
+- Fixed the layout of snos to `starknet_with_keccak` as `all_cairo` is not provable
 - all failed jobs should move to failed state
 - Fixes all unwraps() in code to improve error logging
 - Simplified Update_Job for Database.

--- a/crates/orchestrator/src/jobs/snos_job/mod.rs
+++ b/crates/orchestrator/src/jobs/snos_job/mod.rs
@@ -105,7 +105,7 @@ impl Job for SnosJob {
         let snos_url = snos_url.trim_end_matches('/');
         tracing::debug!(job_id = %job.internal_id, "Calling prove_block function");
         let (cairo_pie, snos_output) =
-            prove_block(block_number, snos_url, LayoutName::all_cairo, false).await.map_err(|e| {
+            prove_block(block_number, snos_url, LayoutName::starknet_with_keccak, false).await.map_err(|e| {
                 tracing::error!(job_id = %job.internal_id, error = %e, "SNOS execution failed");
                 SnosError::SnosExecutionError { internal_id: job.internal_id.clone(), message: e.to_string() }
             })?;


### PR DESCRIPTION
- Currently snos is being run in `all_cairo` layout which is not provable. The correct layout of snos should be `stakrnet_with_keccak`.
- This pr fixes the above issue