### PR TITLE
Endpoints to trigger Process and Verify Jobs

### DIFF
--- a/crates/orchestrator/src/routes/job_routes.rs
+++ b/crates/orchestrator/src/routes/job_routes.rs
@@ -1,0 +1,71 @@
+use std::sync::Arc;
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::Router;
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::config::Config;
+use crate::jobs::{process_job, verify_job, JobError};
+
+#[derive(Deserialize)]
+struct JobParams {
+    id: String,
+}
+
+struct JobResult(Result<(), JobError>);
+
+impl IntoResponse for JobResult {
+    fn into_response(self) -> Response {
+        match self.0 {
+            Ok(_) => (StatusCode::OK, "Job processing completed.").into_response(),
+            Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("Job processing failed: {:?}", e)).into_response(),
+        }
+    }
+}
+
+async fn handle_process_job_request(
+    Query(params): Query<JobParams>,
+    State(config): State<Arc<Config>>,
+) -> impl IntoResponse {
+    let id = match Uuid::parse_str(&params.id) {
+        Ok(id) => id,
+        Err(_) => return (StatusCode::BAD_REQUEST, "Invalid UUID").into_response(),
+    };
+
+    JobResult(process_job(id, config).await).into_response()
+}
+
+async fn handle_verify_job_request(
+    Query(params): Query<JobParams>,
+    State(config): State<Arc<Config>>,
+) -> impl IntoResponse {
+    let id = match Uuid::parse_str(&params.id) {
+        Ok(id) => id,
+        Err(_) => return (StatusCode::BAD_REQUEST, "Invalid UUID").into_response(),
+    };
+
+    JobResult(verify_job(id, config).await).into_response()
+}
+
+pub fn job_routes(config: Arc<Config>) -> Router {
+    Router::new()
+        .route(
+            "/process-job",
+            get({
+                let shared_state = config.clone();
+                move |path| handle_process_job_request(path, State(shared_state))
+            }),
+        )
+        .route(
+            "/verify-job",
+            get({
+                let shared_state = config.clone();
+                move |path| handle_verify_job_request(path, State(shared_state))
+            }),
+        )
+        .with_state(config)
+}

--- a/crates/orchestrator/src/routes/job_routes.rs
+++ b/crates/orchestrator/src/routes/job_routes.rs
@@ -53,19 +53,23 @@ async fn handle_verify_job_request(
 
 pub fn job_routes(config: Arc<Config>) -> Router {
     Router::new()
-        .route(
-            "/process-job",
-            get({
-                let shared_state = config.clone();
-                move |path| handle_process_job_request(path, State(shared_state))
-            }),
-        )
-        .route(
-            "/verify-job",
-            get({
-                let shared_state = config.clone();
-                move |path| handle_verify_job_request(path, State(shared_state))
-            }),
+        .nest(
+            "/trigger",
+            Router::new()
+                .route(
+                    "/process-job",
+                    get({
+                        let shared_state = config.clone();
+                        move |path| handle_process_job_request(path, State(shared_state))
+                    }),
+                )
+                .route(
+                    "/verify-job",
+                    get({
+                        let shared_state = config.clone();
+                        move |path| handle_verify_job_request(path, State(shared_state))
+                    }),
+                ),
         )
         .with_state(config)
 }

--- a/crates/orchestrator/src/routes/mod.rs
+++ b/crates/orchestrator/src/routes/mod.rs
@@ -1,0 +1,2 @@
+pub mod job_routes;
+pub mod routes;

--- a/crates/orchestrator/src/routes/routes.rs
+++ b/crates/orchestrator/src/routes/routes.rs
@@ -4,14 +4,14 @@ use axum::routing::get;
 use axum::Router;
 
 pub fn app_router() -> Router {
-    Router::new().route("/health", get(root)).nest("/v1/dev", dev_routes()).fallback(handler_404)
+    Router::new().route("/health", get(root)).nest("/v1/dev", dev_routes())
 }
 
 async fn root() -> &'static str {
     "UP"
 }
 
-async fn handler_404() -> impl IntoResponse {
+pub async fn handler_404() -> impl IntoResponse {
     (StatusCode::NOT_FOUND, "The requested resource was not found")
 }
 

--- a/crates/orchestrator/src/tests/server/mod.rs
+++ b/crates/orchestrator/src/tests/server/mod.rs
@@ -11,7 +11,7 @@ use url::Url;
 use utils::env_utils::get_env_var_or_default;
 
 use crate::queue::init_consumers;
-use crate::routes::app_router;
+use crate::routes::routes::app_router;
 use crate::tests::config::TestConfigBuilder;
 
 #[fixture]


### PR DESCRIPTION
This PR adds two endpoints `/trigger/process_job` and `/trigger/verify_job` which takes an id as query param, if id refers to a valid unprocessed/unverified job, it triggers for the same. 