### PR TITLE
fix: indexing for get_jobs_without_successor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Fixed
 
+- indexing for get_jobs_without_successor
 - wait for transaction logic in ethereum settlement client
 - y_0 point evaluation in build kzg proof for ethereum settlement
 - fixed metrics name, signoz dashboard.

--- a/migrations/00000000000000-init.js
+++ b/migrations/00000000000000-init.js
@@ -8,6 +8,9 @@ module.exports = {
         { key: { job_type: 1, internal_id: -1 }, unique: true },
         { key: { job_type: 1, status: 1, internal_id: -1 } },
         { key: { status: 1 } },
+        // primarily for get_jobs_without_successor
+        { key: { job_type: 1, status: 1 } },
+        { key: { job_type: 1, internal_id: 1 } },
       ]);
   },
 
@@ -17,5 +20,8 @@ module.exports = {
     await db.collection("jobs").dropIndex("job_type_1_internal_id_-1");
     await db.collection("jobs").dropIndex("job_type_1_status_1_internal_id_-1");
     await db.collection("jobs").dropIndex("status_1");
+    await db.collection("jobs").dropIndex("job_type_1_status_1");
+    await db.collection("jobs").dropIndex("job_type_1_internal_id_1");
   },
 };
+  

--- a/migrations/00000000000000-init.js
+++ b/migrations/00000000000000-init.js
@@ -8,7 +8,6 @@ module.exports = {
       { key: { status: 1 } },
       // primarily for get_jobs_without_successor
       { key: { job_type: 1, status: 1 } },
-      { key: { job_type: 1, internal_id: 1 } },
     ]);
   },
 
@@ -19,6 +18,5 @@ module.exports = {
     await db.collection("jobs").dropIndex("job_type_1_status_1_internal_id_-1");
     await db.collection("jobs").dropIndex("status_1");
     await db.collection("jobs").dropIndex("job_type_1_status_1");
-    await db.collection("jobs").dropIndex("job_type_1_internal_id_1");
   },
 };

--- a/migrations/00000000000000-init.js
+++ b/migrations/00000000000000-init.js
@@ -1,17 +1,15 @@
 module.exports = {
   async up(db) {
     // Create indexes for the 'jobs' collection
-    await db
-      .collection("jobs")
-      .createIndexes([
-        { key: { id: 1 } },
-        { key: { job_type: 1, internal_id: -1 }, unique: true },
-        { key: { job_type: 1, status: 1, internal_id: -1 } },
-        { key: { status: 1 } },
-        // primarily for get_jobs_without_successor
-        { key: { job_type: 1, status: 1 } },
-        { key: { job_type: 1, internal_id: 1 } },
-      ]);
+    await db.collection("jobs").createIndexes([
+      { key: { id: 1 } },
+      { key: { job_type: 1, internal_id: -1 }, unique: true },
+      { key: { job_type: 1, status: 1, internal_id: -1 } },
+      { key: { status: 1 } },
+      // primarily for get_jobs_without_successor
+      { key: { job_type: 1, status: 1 } },
+      { key: { job_type: 1, internal_id: 1 } },
+    ]);
   },
 
   async down(db) {
@@ -24,4 +22,3 @@ module.exports = {
     await db.collection("jobs").dropIndex("job_type_1_internal_id_1");
   },
 };
-  


### PR DESCRIPTION
`get_jobs_without_successor` was clocking at 5 seconds query time,
added indexes on : 
- { "job_type": 1, "status": 1 }
- { "job_type": 1, "internal_id": 1 }
now, it's reduces to `30 ms`