### PR TITLE
 Add Atlantic support to clap and improve status handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,7 +1779,7 @@ dependencies = [
  "alloy 0.2.1",
  "async-trait",
  "base64 0.22.1",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
  "chrono",
  "color-eyre",
  "dotenvy",
@@ -3378,7 +3378,7 @@ dependencies = [
 [[package]]
 name = "cairo-type-derive"
 version = "0.1.0"
-source = "git+https://github.com/Mohiiit/snos?rev=2dcd3b0f0c6bfa368a802de12de29cd124c72bb8#2dcd3b0f0c6bfa368a802de12de29cd124c72bb8"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=23879ebc79d9572ce11f2c9768ffeea7a8455efa#23879ebc79d9572ce11f2c9768ffeea7a8455efa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3419,7 +3419,7 @@ dependencies = [
 [[package]]
 name = "cairo-vm"
 version = "1.0.1"
-source = "git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization#6036ab9533e1754f1612fbea9c9d2a27063ca5f8"
+source = "git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04#1fa902bafae507424b5ea83a625830ffe6b0eca5"
 dependencies = [
  "anyhow",
  "ark-ff 0.4.2",
@@ -4516,7 +4516,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "c-kzg",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
  "color-eyre",
  "dotenvy",
  "lazy_static",
@@ -5074,7 +5074,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "bincode 1.3.3",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
  "dotenvy",
  "itertools 0.13.0",
  "log",
@@ -6888,7 +6888,7 @@ dependencies = [
  "bincode 1.3.3",
  "bytes",
  "c-kzg",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
  "chrono",
  "clap",
  "color-eyre",
@@ -7677,13 +7677,13 @@ dependencies = [
 [[package]]
 name = "prove_block"
 version = "0.1.0"
-source = "git+https://github.com/Mohiiit/snos?rev=2dcd3b0f0c6bfa368a802de12de29cd124c72bb8#2dcd3b0f0c6bfa368a802de12de29cd124c72bb8"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=23879ebc79d9572ce11f2c9768ffeea7a8455efa#23879ebc79d9572ce11f2c9768ffeea7a8455efa"
 dependencies = [
  "anyhow",
  "blockifier",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
  "clap",
  "env_logger",
  "futures-core",
@@ -7712,7 +7712,7 @@ name = "prover-client-interface"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
  "gps-fact-checker",
  "mockall",
  "starknet-os",
@@ -8140,7 +8140,7 @@ dependencies = [
 [[package]]
 name = "rpc-client"
 version = "0.1.0"
-source = "git+https://github.com/Mohiiit/snos?rev=2dcd3b0f0c6bfa368a802de12de29cd124c72bb8#2dcd3b0f0c6bfa368a802de12de29cd124c72bb8"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=23879ebc79d9572ce11f2c9768ffeea7a8455efa#23879ebc79d9572ce11f2c9768ffeea7a8455efa"
 dependencies = [
  "log",
  "reqwest 0.11.27",
@@ -8155,7 +8155,7 @@ dependencies = [
 [[package]]
 name = "rpc-replay"
 version = "0.1.0"
-source = "git+https://github.com/Mohiiit/snos?rev=2dcd3b0f0c6bfa368a802de12de29cd124c72bb8#2dcd3b0f0c6bfa368a802de12de29cd124c72bb8"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=23879ebc79d9572ce11f2c9768ffeea7a8455efa#23879ebc79d9572ce11f2c9768ffeea7a8455efa"
 dependencies = [
  "blockifier",
  "cairo-lang-starknet-classes",
@@ -9086,7 +9086,7 @@ dependencies = [
  "alloy 0.2.1",
  "async-trait",
  "base64 0.22.1",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
  "color-eyre",
  "dotenvy",
  "gps-fact-checker",
@@ -9518,7 +9518,7 @@ dependencies = [
 [[package]]
 name = "starknet-os"
 version = "0.1.0"
-source = "git+https://github.com/Mohiiit/snos?rev=2dcd3b0f0c6bfa368a802de12de29cd124c72bb8#2dcd3b0f0c6bfa368a802de12de29cd124c72bb8"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=23879ebc79d9572ce11f2c9768ffeea7a8455efa#23879ebc79d9572ce11f2c9768ffeea7a8455efa"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -9533,7 +9533,7 @@ dependencies = [
  "cairo-lang-starknet",
  "cairo-lang-starknet-classes",
  "cairo-type-derive",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
  "futures",
  "futures-util",
  "heck 0.4.1",
@@ -9567,11 +9567,11 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.1.0"
-source = "git+https://github.com/Mohiiit/snos?rev=2dcd3b0f0c6bfa368a802de12de29cd124c72bb8#2dcd3b0f0c6bfa368a802de12de29cd124c72bb8"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=23879ebc79d9572ce11f2c9768ffeea7a8455efa#23879ebc79d9572ce11f2c9768ffeea7a8455efa"
 dependencies = [
  "blockifier",
  "cairo-lang-starknet-classes",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
  "flate2",
  "num-bigint",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,16 +122,17 @@ tracing-subscriber = { version = "0.3.18", features = [
 tracing-opentelemetry = "0.26.0"
 
 # Cairo VM
-cairo-vm = { git = "https://github.com/Moonsong-Labs/cairo-vm", branch = "herman/fix-pie-serialization", features = [
+cairo-vm = { git = "https://github.com/Moonsong-Labs/cairo-vm", branch = "notlesh/snos-2024-11-04", features = [
   "cairo-1-hints",
   "extensive_hints",
   "mod_builtin",
 ] }
 
+
 # Snos & Sharp (Starkware)
 # TODO: need to update this once the updated PR merges
-starknet-os = { git = "https://github.com/Mohiiit/snos", rev = "2dcd3b0f0c6bfa368a802de12de29cd124c72bb8" }
-prove_block = { git = "https://github.com/Mohiiit/snos", rev = "2dcd3b0f0c6bfa368a802de12de29cd124c72bb8" }
+starknet-os = { git = "https://github.com/keep-starknet-strange/snos", rev = "23879ebc79d9572ce11f2c9768ffeea7a8455efa" }
+prove_block = { git = "https://github.com/keep-starknet-strange/snos", rev = "23879ebc79d9572ce11f2c9768ffeea7a8455efa" }
 
 
 # Madara prover API

--- a/crates/orchestrator/src/cli/mod.rs
+++ b/crates/orchestrator/src/cli/mod.rs
@@ -89,7 +89,7 @@ pub enum Commands {
     ),
     group(
         ArgGroup::new("prover")
-            .args(&["sharp"])
+            .args(&["sharp", "atlantic"])
             .required(true)
             .multiple(false)
     ),

--- a/crates/orchestrator/src/jobs/proving_job/mod.rs
+++ b/crates/orchestrator/src/jobs/proving_job/mod.rs
@@ -128,6 +128,9 @@ impl Job for ProvingJob {
                 Ok(JobVerificationStatus::Pending)
             }
             TaskStatus::Succeeded => {
+                // TODO: call isValid on the contract over here to cross-verify whether the proof was registered on
+                // chain or not
+
                 tracing::info!(log_type = "completed", category = "proving", function_type = "verify_job", job_id = ?job.id,  block_no = %internal_id,     "Proving job verification completed.");
                 Ok(JobVerificationStatus::Verified)
             }

--- a/crates/prover-clients/atlantic-service/src/lib.rs
+++ b/crates/prover-clients/atlantic-service/src/lib.rs
@@ -1,6 +1,9 @@
 pub mod client;
 pub mod error;
 mod types;
+use std::str::FromStr;
+
+use alloy::primitives::B256;
 use async_trait::async_trait;
 use cairo_vm::types::layout_name::LayoutName;
 use gps_fact_checker::FactChecker;
@@ -9,6 +12,7 @@ use tempfile::NamedTempFile;
 use url::Url;
 
 use crate::client::AtlanticClient;
+use crate::types::SharpQueryStatus;
 
 pub const ATLANTIC_SETTINGS_NAME: &str = "atlantic";
 
@@ -54,36 +58,36 @@ impl ProverClient for AtlanticProverService {
                 let atlantic_job_response =
                     self.atlantic_client.add_job(pie_file_path, proof_layout, self.atlantic_api_key.clone()).await?;
                 // sleep for 2 seconds to make sure the job is submitted
-                tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
                 log::debug!("Successfully submitted task to atlantic: {:?}", atlantic_job_response);
                 // The temporary file will be automatically deleted when `temp_file` goes out of scope
-                Ok(atlantic_job_response.sharp_query_id)
+                Ok(atlantic_job_response.atlantic_query_id)
             }
         }
     }
 
     #[tracing::instrument(skip(self))]
     async fn get_task_status(&self, job_key: &str, fact: &str) -> Result<TaskStatus, ProverClientError> {
-        // let res = self.atlantic_client.get_job_status(job_key).await?;
-        //
-        // match res.sharp_query.status {
-        //     SharpQueryStatus::InProgress => Ok(TaskStatus::Processing),
-        //     SharpQueryStatus::Done => {
-        //         let fact = B256::from_str(fact).map_err(|e|
-        // ProverClientError::FailedToConvertFact(e.to_string()))?;         if
-        // self.fact_checker.is_valid(&fact).await? {             Ok(TaskStatus::Succeeded)
-        //         } else {
-        //             Ok(TaskStatus::Failed(format!("Fact {} is not valid or not registered",
-        // hex::encode(fact))))         }
-        //     }
-        //     SharpQueryStatus::Failed => {
-        //         Ok(TaskStatus::Failed("Task failed while processing on Atlantic side".to_string()))
-        //     }
-        // }
+        let res = self.atlantic_client.get_job_status(job_key).await?;
+        // TODO:
+        match res.atlantic_query.status {
+            SharpQueryStatus::InProgress => Ok(TaskStatus::Processing),
+            SharpQueryStatus::Done => {
+                let fact = B256::from_str(fact).map_err(|e| ProverClientError::FailedToConvertFact(e.to_string()))?;
+                if self.fact_checker.is_valid(&fact).await? {
+                    Ok(TaskStatus::Succeeded)
+                } else {
+                    Ok(TaskStatus::Failed(format!("Fact {} is not valid or not registered", hex::encode(fact))))
+                }
+            }
+            SharpQueryStatus::Failed => {
+                Ok(TaskStatus::Failed("Task failed while processing on Atlantic side".to_string()))
+            }
+        }
 
         // TODO: Commented the above code since, atlantic infra is not able
         // to prove snos blocks currently so to run e2e tests returning Succeeded.
-        Ok(TaskStatus::Succeeded)
+        // Ok(TaskStatus::Succeeded)
     }
 }
 

--- a/crates/prover-clients/atlantic-service/src/types.rs
+++ b/crates/prover-clients/atlantic-service/src/types.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AtlanticAddJobResponse {
-    pub sharp_query_id: String,
+    pub atlantic_query_id: String,
 }
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION

## Changes
- Integrated Atlantic into the existing CLAP implementation
- Enhanced `get_status` functionality for Atlantic to handle succeeded state

## Details
The PR introduces Atlantic support in our command-line interface while improving the status checking logic. The status check now properly waits for and verifies the "succeeded" state, ensuring that we wait for the atlantic service to respond before moving on.
