### PR TITLE
Refactor: RUST_LOG filtering

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -12,7 +12,7 @@ jobs:
 
     services:
       localstack:
-        image: localstack/localstack@sha256:e5f984056f8e1f3ea0d0c595dd6a02846f2a665443bab18110a487b065f8164f
+        image: localstack/localstack@sha256:763947722c6c8d33d5fbf7e8d52b4bddec5be35274a0998fdc6176d733375314
         
         env:
           DEFAULT_REGION: us-east-1

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -13,7 +13,7 @@ jobs:
     services:
       localstack:
         image: localstack/localstack@sha256:763947722c6c8d33d5fbf7e8d52b4bddec5be35274a0998fdc6176d733375314
-        
+
         env:
           DEFAULT_REGION: us-east-1
           AWS_ACCESS_KEY_ID: "AWS_ACCESS_KEY_ID"

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -12,7 +12,8 @@ jobs:
 
     services:
       localstack:
-        image: localstack/localstack
+        image: localstack/localstack@sha256:e5f984056f8e1f3ea0d0c595dd6a02846f2a665443bab18110a487b065f8164f
+        
         env:
           DEFAULT_REGION: us-east-1
           AWS_ACCESS_KEY_ID: "AWS_ACCESS_KEY_ID"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Fixed
 
+- refactor: RUST_LOG filtering support
 - refactor: cargo.toml files cleaned
 - blob data formation process from state update
 - OTEL config refactor

--- a/crates/orchestrator/src/cli/instrumentation.rs
+++ b/crates/orchestrator/src/cli/instrumentation.rs
@@ -1,5 +1,4 @@
 use clap::Args;
-use tracing::Level;
 use url::Url;
 
 /// Parameters used to config instrumentation.
@@ -13,8 +12,4 @@ pub struct InstrumentationCliArgs {
     /// The endpoint of the collector.
     #[arg(env = "MADARA_ORCHESTRATOR_OTEL_COLLECTOR_ENDPOINT", long)]
     pub otel_collector_endpoint: Option<Url>,
-
-    /// The log level.
-    #[arg(env = "RUST_LOG", long, default_value = "INFO")]
-    pub log_level: Level,
 }

--- a/crates/orchestrator/src/cli/mod.rs
+++ b/crates/orchestrator/src/cli/mod.rs
@@ -612,7 +612,6 @@ pub mod validate_params {
     pub mod test {
 
         use rstest::rstest;
-        
         use url::Url;
 
         use crate::cli::alert::aws_sns::AWSSNSCliArgs;

--- a/crates/orchestrator/src/cli/mod.rs
+++ b/crates/orchestrator/src/cli/mod.rs
@@ -559,7 +559,6 @@ pub mod validate_params {
         Ok(InstrumentationParams {
             otel_service_name: instrumentation_args.otel_service_name.clone().expect("Otel service name is required"),
             otel_collector_endpoint: instrumentation_args.otel_collector_endpoint.clone(),
-            log_level: instrumentation_args.log_level,
         })
     }
 
@@ -613,7 +612,7 @@ pub mod validate_params {
     pub mod test {
 
         use rstest::rstest;
-        use tracing::Level;
+        
         use url::Url;
 
         use crate::cli::alert::aws_sns::AWSSNSCliArgs;
@@ -850,11 +849,8 @@ pub mod validate_params {
 
         #[rstest]
         fn test_validate_instrumentation_params() {
-            let instrumentation_args: InstrumentationCliArgs = InstrumentationCliArgs {
-                otel_service_name: Some("".to_string()),
-                otel_collector_endpoint: None,
-                log_level: Level::INFO,
-            };
+            let instrumentation_args: InstrumentationCliArgs =
+                InstrumentationCliArgs { otel_service_name: Some("".to_string()), otel_collector_endpoint: None };
             let instrumentation_params = validate_instrumentation_params(&instrumentation_args);
             assert!(instrumentation_params.is_ok());
         }

--- a/crates/orchestrator/src/telemetry.rs
+++ b/crates/orchestrator/src/telemetry.rs
@@ -9,7 +9,6 @@ use opentelemetry_sdk::metrics::reader::{DefaultAggregationSelector, DefaultTemp
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::trace::{BatchConfigBuilder, Config, Tracer};
 use opentelemetry_sdk::{runtime, Resource};
-use tracing::Level;
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
@@ -25,17 +24,13 @@ pub struct OTELConfig {
 pub struct InstrumentationParams {
     pub otel_service_name: String,
     pub otel_collector_endpoint: Option<Url>,
-    pub log_level: Level,
 }
 
 pub fn setup_analytics(instrumentation: &InstrumentationParams) -> Option<SdkMeterProvider> {
     let otel_config = get_otel_config(instrumentation);
-    let level = instrumentation.log_level;
 
-    let tracing_subscriber = tracing_subscriber::registry()
-        .with(tracing_subscriber::filter::LevelFilter::from_level(level))
-        .with(tracing_subscriber::fmt::layer())
-        .with(EnvFilter::from_default_env());
+    let tracing_subscriber =
+        tracing_subscriber::registry().with(tracing_subscriber::fmt::layer()).with(EnvFilter::from_default_env());
 
     if let Some(otel_config) = otel_config {
         let meter_provider = init_metric_provider(&otel_config);
@@ -147,7 +142,7 @@ fn init_logs(otel_config: &OTELConfig) -> Result<LoggerProvider, opentelemetry::
 #[cfg(test)]
 mod tests {
     use once_cell::sync::Lazy;
-    use tracing::Level;
+    
     use utils::metrics::lib::Metrics;
     use utils::register_metric;
 
@@ -161,7 +156,6 @@ mod tests {
         let instrumentation_params = InstrumentationParams {
             otel_collector_endpoint: Some(Url::parse("http://localhost:4317").unwrap()),
             otel_service_name: "test_service".to_string(),
-            log_level: Level::INFO,
         };
 
         let otel_config = get_otel_config(&instrumentation_params).unwrap();
@@ -183,7 +177,6 @@ mod tests {
         let instrumentation_params = InstrumentationParams {
             otel_collector_endpoint: Some(Url::parse("http://localhost:4317").unwrap()),
             otel_service_name: "test_service".to_string(),
-            log_level: Level::INFO,
         };
 
         let otel_config = get_otel_config(&instrumentation_params).unwrap();
@@ -203,7 +196,6 @@ mod tests {
         let instrumentation_params = InstrumentationParams {
             otel_collector_endpoint: Some(Url::parse("http://localhost:4317").unwrap()),
             otel_service_name: "test_service".to_string(),
-            log_level: Level::INFO,
         };
 
         let analytics = setup_analytics(&instrumentation_params);
@@ -219,7 +211,6 @@ mod tests {
         let instrumentation_params = InstrumentationParams {
             otel_collector_endpoint: Some(Url::parse("http://localhost:4317").unwrap()),
             otel_service_name: "test_service".to_string(),
-            log_level: Level::INFO,
         };
 
         setup_analytics(&instrumentation_params);

--- a/crates/orchestrator/src/telemetry.rs
+++ b/crates/orchestrator/src/telemetry.rs
@@ -142,7 +142,6 @@ fn init_logs(otel_config: &OTELConfig) -> Result<LoggerProvider, opentelemetry::
 #[cfg(test)]
 mod tests {
     use once_cell::sync::Lazy;
-    
     use utils::metrics::lib::Metrics;
     use utils::register_metric;
 

--- a/crates/orchestrator/src/tests/config.rs
+++ b/crates/orchestrator/src/tests/config.rs
@@ -14,9 +14,8 @@ use settlement_client_interface::{MockSettlementClient, SettlementClient};
 use sharp_service::SharpValidatedArgs;
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
-use tracing::Level;
 use url::Url;
-use utils::env_utils::{get_env_var_optional, get_env_var_or_default, get_env_var_or_panic};
+use utils::env_utils::{get_env_var_optional, get_env_var_or_panic};
 
 use crate::alerts::aws_sns::AWSSNSValidatedArgs;
 use crate::alerts::Alerts;
@@ -565,7 +564,6 @@ fn get_env_params() -> EnvParams {
         otel_collector_endpoint: get_env_var_optional("MADARA_ORCHESTRATOR_OTEL_COLLECTOR_ENDPOINT")
             .expect("Couldn't get otel collector endpoint")
             .map(|url| Url::parse(&url).expect("Failed to parse MADARA_ORCHESTRATOR_OTEL_COLLECTOR_ENDPOINT")),
-        log_level: Level::from_str(&get_env_var_or_default("RUST_LOG", "info")).expect("Failed to parse RUST_LOG"),
     };
 
     let prover_params = ProverValidatedArgs::Sharp(SharpValidatedArgs {


### PR DESCRIPTION
Filtering based on RUST_LOG stopped working after clap integration.
removed log_level from clap to get it to working again
