### PR TITLE
fixed: instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Fixed
 
-- refactor: instrumentations
+- refactor: instrumentation
 - `is_worker_enabled` status check moved from `VerificationFailed` to `Failed`
 - refactor: static attributes for telemetry
 - refactor: aws setup for Event Bridge


### PR DESCRIPTION
The previous fix did not work for `process_job` because `job` that was being sent was not updated with the `external_id` received, we could fetch it again, but doing a DB operation for metrics is a heavy call, hence here we are sending individual components with their most updated values.
 